### PR TITLE
Fix issues with OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ OPTION(MODULE_ROUNDING "Activate rounding module" ON)
 OPTION(MODULE_COREFINEMENT "Activate corefining module" ON)
 OPTION(MODULE_SPAMOD "Activate spamod module" OFF)
 OPTION(MODULE_EXTRACTION_IMAGE "Activate extraction image module (require ImageMagick++)" ON)
+OPTION(DISABLE_SELECTION_BOX "Disable the selection box on a 3D view" OFF)
 
 #-------------------------------------------------------------------------------
 # Some compiler options that we can enable with some ADD_DEFINITIONS(xxx).
@@ -179,6 +180,10 @@ if ( MODULE_EXTRACTION_IMAGE )
   include_directories(${CMAKE_SOURCE_DIR}/src/lib-extraction-images)
   add_subdirectory   (src/lib-extraction-images lib-extraction-images)
 endif ( MODULE_EXTRACTION_IMAGE )
+#-------------------------------------------------------------------------------
+if (DISABLE_SELECTION_BOX)
+  add_definitions(-DDISABLE_SELECTION_BOX)
+endif (DISABLE_SELECTION_BOX)
 #-------------------------------------------------------------------------------
 add_subdirectory (src/lib-gmapkernel lib-gmapkernel)
 add_subdirectory (src/lib-controler lib-controler)

--- a/src/lib-gmapkernel/tools/geometry/geometry.hh
+++ b/src/lib-gmapkernel/tools/geometry/geometry.hh
@@ -457,7 +457,7 @@ public:
   { double coord[3]; };
   struct CompareCoord3D
   {
-    bool operator()(const Coord3D& lhs, const Coord3D& rhs)
+    bool operator()(const Coord3D& lhs, const Coord3D& rhs) const
     {
       unsigned dec=10;
       double lhsx=redondeo(lhs.coord[0],dec);

--- a/src/mokaQtIhm/windows/gl-window.qt.cc
+++ b/src/mokaQtIhm/windows/gl-window.qt.cc
@@ -127,7 +127,7 @@ void GLWindow::closeEvent(QCloseEvent * e)
 //************************************************************
 void GLWindow::paintGL()
 {
-  QPainter p(this);
+//  QPainter p(this);
 
   makeCurrent();
   glPushAttrib(GL_ALL_ATTRIB_BITS);
@@ -154,16 +154,16 @@ void GLWindow::paintGL()
   glPopMatrix();
   glPopAttrib();
 
-  if (FDragMode)
-    {
-      p.setPen(Qt::white) ;
-      p.drawRect(FStartX, FStartY, FCurX - FStartX, FCurY - FStartY);
-      if ( FOwner->getControler()->getModeDeselectionAtStop() )
-	p.drawText(FStartX, FStartY, "Deselect");
-      else
-	p.drawText(FStartX, FStartY, "Select");
-    }
-  p.end();
+//  if (FDragMode)
+//    {
+//      p.setPen(Qt::white) ;
+//      p.drawRect(FStartX, FStartY, FCurX - FStartX, FCurY - FStartY);
+//      if ( FOwner->getControler()->getModeDeselectionAtStop() )
+//	p.drawText(FStartX, FStartY, "Deselect");
+//      else
+//	p.drawText(FStartX, FStartY, "Select");
+//    }
+//  p.end();
 }
 //************************************************************
 // Modif de la taille de la fenetre

--- a/src/mokaQtIhm/windows/gl-window.qt.cc
+++ b/src/mokaQtIhm/windows/gl-window.qt.cc
@@ -127,7 +127,9 @@ void GLWindow::closeEvent(QCloseEvent * e)
 //************************************************************
 void GLWindow::paintGL()
 {
-//  QPainter p(this);
+#ifndef DISABLE_SELECTION_BOX
+  QPainter p(this);
+#endif
 
   makeCurrent();
   glPushAttrib(GL_ALL_ATTRIB_BITS);
@@ -154,16 +156,18 @@ void GLWindow::paintGL()
   glPopMatrix();
   glPopAttrib();
 
-//  if (FDragMode)
-//    {
-//      p.setPen(Qt::white) ;
-//      p.drawRect(FStartX, FStartY, FCurX - FStartX, FCurY - FStartY);
-//      if ( FOwner->getControler()->getModeDeselectionAtStop() )
-//	p.drawText(FStartX, FStartY, "Deselect");
-//      else
-//	p.drawText(FStartX, FStartY, "Select");
-//    }
-//  p.end();
+#ifndef DISABLE_SELECTION_BOX
+  if (FDragMode)
+    {
+      p.setPen(Qt::white) ;
+      p.drawRect(FStartX, FStartY, FCurX - FStartX, FCurY - FStartY);
+      if ( FOwner->getControler()->getModeDeselectionAtStop() )
+        p.drawText(FStartX, FStartY, "Deselect");
+      else
+        p.drawText(FStartX, FStartY, "Select");
+    }
+  p.end();
+#endif
 }
 //************************************************************
 // Modif de la taille de la fenetre


### PR DESCRIPTION
Those patches fix some issues with OSX.

The first patch is a fix in order to stop clang from complaining and allow to build.

The second is a temporary removal of the rectangle selection functionality on a normal 3D view window, as the QPainter causes the 3D view to turn completely red and nothing is visible. There was a similar behaviour under Linux, as well, when I tried.