### PR TITLE
Migrate to Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ find_package(ASSIMP)
 
 if ( ASSIMP_FOUND )
    ADD_DEFINITIONS(-DWITH_ASSIMP)
-   include_directories(${ASSIMP_INCLUDE_DIRS})
+   include_directories(${ASSIMP_INCLUDE_DIR})
 endif ( ASSIMP_FOUND )
 
 #------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ OPTION(MODULE_ROUNDING "Activate rounding module" ON)
 OPTION(MODULE_COREFINEMENT "Activate corefining module" ON)
 OPTION(MODULE_SPAMOD "Activate spamod module" OFF)
 OPTION(MODULE_EXTRACTION_IMAGE "Activate extraction image module (require ImageMagick++)" ON)
+OPTION(DISABLE_SELECTION_BOX "Disable the selection box on a 3D view" OFF)
 
 #-------------------------------------------------------------------------------
 # Some compiler options that we can enable with some ADD_DEFINITIONS(xxx).
@@ -179,6 +180,10 @@ if ( MODULE_EXTRACTION_IMAGE )
   include_directories(${CMAKE_SOURCE_DIR}/src/lib-extraction-images)
   add_subdirectory   (src/lib-extraction-images lib-extraction-images)
 endif ( MODULE_EXTRACTION_IMAGE )
+#-------------------------------------------------------------------------------
+if (DISABLE_SELECTION_BOX)
+  add_definitions(-DDISABLE_SELECTION_BOX)
+endif (DISABLE_SELECTION_BOX)
 #-------------------------------------------------------------------------------
 add_subdirectory (src/lib-gmapkernel lib-gmapkernel)
 add_subdirectory (src/lib-controler lib-controler)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ OPTION(BUILD_SHARED_LIBS "Build shared libraries." OFF)
 # SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pg")
 
 # To enable c++11
-# ADD_DEFINITIONS("-std=c++11")
+ ADD_DEFINITIONS("-std=c++11")
 
 #-------------------------------------------------------------------------------
 # Some modules that we can enable or disable.

--- a/src/lib-controler-gmap/operations/operations-move-selection.cc
+++ b/src/lib-controler-gmap/operations/operations-move-selection.cc
@@ -62,6 +62,7 @@ bool CControlerGMap::goForward1()
   CDart* next = FMap->go(CGMapGeneric::Forward, getLastSelectedDart(),
 			 getSelectionOrbit(), getSelectionMark(), true);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Forward selection done");
   return true;
 }
@@ -74,6 +75,7 @@ bool CControlerGMap::goForward0()
   CDart* next = FMap->go(CGMapGeneric::Forward, getLastSelectedDart(),
 			 getSelectionOrbit(), getSelectionMark(), false);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Forward deselection done");
   return true;
 }
@@ -86,6 +88,7 @@ bool CControlerGMap::goBackward1()
   CDart* next = FMap->go(CGMapGeneric::Backward, getLastSelectedDart(),
 			 getSelectionOrbit(), getSelectionMark(), true);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Backward selection done");
   return true;
 }
@@ -98,6 +101,7 @@ bool CControlerGMap::goBackward0()
   CDart* next = FMap->go(CGMapGeneric::Backward, getLastSelectedDart(),
 			 getSelectionOrbit(), getSelectionMark(), false);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Backward deselection done");
   return true;
 }
@@ -110,6 +114,7 @@ bool CControlerGMap::goLeft1()
   CDart* next = FMap->go(CGMapGeneric::Left, getLastSelectedDart(),
 			 getSelectionOrbit(), getSelectionMark(), true);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Left selection done");
   return true;
 }
@@ -122,6 +127,7 @@ bool CControlerGMap::goLeft0()
   CDart* next = FMap->go(CGMapGeneric::Left, getLastSelectedDart(),
 			 getSelectionOrbit(), getSelectionMark(), false);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Left deselection done");
   return true;
 }
@@ -134,6 +140,7 @@ bool CControlerGMap::goRight1()
   CDart* next = FMap->go(CGMapGeneric::Right, getLastSelectedDart(),
 			 getSelectionOrbit(), getSelectionMark(), true);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Right selection done");
   return true;
 }
@@ -146,6 +153,7 @@ bool CControlerGMap::goRight0()
   CDart* next = FMap->go(CGMapGeneric::Right, getLastSelectedDart(),
 			 getSelectionOrbit(), getSelectionMark(), false);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Right deselection done");
   return true;
 }
@@ -160,6 +168,7 @@ bool CControlerGMap::goForward1Rep()
 					getSelectionOrbit(),
 					getSelectionMark(), true);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Forward selection done");
   return true;
 }
@@ -174,6 +183,7 @@ bool CControlerGMap::goForward0Rep()
 					getSelectionOrbit(),
 					getSelectionMark(), false);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Forward deselection done");
   return true;
 }
@@ -188,6 +198,7 @@ bool CControlerGMap::goBackward1Rep()
 					getSelectionOrbit(),
 					getSelectionMark(), true);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Backward selection done");
   return true;
 }
@@ -202,6 +213,7 @@ bool CControlerGMap::goBackward0Rep()
 					getSelectionOrbit(),
 					getSelectionMark(), false);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Backward deselection done");
   return true;
 }
@@ -216,6 +228,7 @@ bool CControlerGMap::goLeft1Rep()
 					getSelectionOrbit(),
 					getSelectionMark(), true);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Left selection done");
   return true;
 }
@@ -230,6 +243,7 @@ bool CControlerGMap::goLeft0Rep()
 					getSelectionOrbit(),
 					getSelectionMark(), false);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Left deselection done");
   return true;
 }
@@ -244,6 +258,7 @@ bool CControlerGMap::goRight1Rep()
 					getSelectionOrbit(),
 					getSelectionMark(), true);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Right selection done");
   return true;
 }
@@ -258,6 +273,7 @@ bool CControlerGMap::goRight0Rep()
 					getSelectionOrbit(),
 					getSelectionMark(), false);
   selectDart(next);
+  setSelectionChanged();
   setMessage("Right deselection done");
   return true;
 }
@@ -282,6 +298,7 @@ bool CControlerGMap::goAlphai( unsigned int ADim )
   if ( !FMap->isFree(getLastSelectedDart(),ADim) )
     {
       selectDart(FMap->alpha(getLastSelectedDart(),ADim));
+      setSelectionChanged();
       setMessage("Selection by alpha", ADim, " done");
     }
   else

--- a/src/lib-gmapkernel/tools/geometry/geometry.hh
+++ b/src/lib-gmapkernel/tools/geometry/geometry.hh
@@ -457,7 +457,7 @@ public:
   { double coord[3]; };
   struct CompareCoord3D
   {
-    bool operator()(const Coord3D& lhs, const Coord3D& rhs)
+    bool operator()(const Coord3D& lhs, const Coord3D& rhs) const
     {
       unsigned dec=10;
       double lhsx=redondeo(lhs.coord[0],dec);

--- a/src/mokaQtIhm/CMakeLists.txt
+++ b/src/mokaQtIhm/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_CXX_STANDARD 14)
+
 #-------------------------------------------------------------------------------
 include_directories(object-creations/ 
                     object-mesh/ 
@@ -11,24 +13,27 @@ file(GLOB_RECURSE NEED_MOCS *.qt.hh)
 set (QT_RESOURCES Icones/icones.qrc)
 #-------------------------------------------------------------------------------
 # We need QT4 library
-SET( QT_USE_QT3SUPPORT TRUE )
-SET( QT_USE_QTOPENGL  TRUE )
-SET( QT_USE_QTGUI  TRUE )
+#SET( QT_USE_QT3SUPPORT TRUE )
+#SET( QT_USE_QTOPENGL  TRUE )
+#SET( QT_USE_QTGUI  TRUE )
 
-FIND_PACKAGE(Qt4 REQUIRED)
-INCLUDE(${QT_USE_FILE})
+#FIND_PACKAGE(Qt4 REQUIRED)
+#INCLUDE(${QT_USE_FILE})
+
+find_package(Qt5Widgets)
 
 add_definitions(${QT_DEFINITIONS})
 include_directories (${QT_QTOPENGL_INCLUDE_DIR})
 INCLUDE_DIRECTORIES( ${CMAKE_BINARY_DIR} )
 
-QT4_WRAP_CPP(MOC_SRCS ${NEED_MOCS})
-QT4_ADD_RESOURCES(RESOURCES_SRCS ${QT_RESOURCES})
+QT5_WRAP_CPP(MOC_SRCS ${NEED_MOCS})
+QT5_ADD_RESOURCES(RESOURCES_SRCS ${QT_RESOURCES})
 #-------------------------------------------------------------------------------
-add_executable(mokaQt ${IHM_SRCS} ${MOC_SRCS} ${RESOURCES_SRCS} ${NEED_MOCS})
+add_executable(mokaQt ${IHM_SRCS} ${MOC_SRCS} ${QT_RESOURCES} ${NEED_MOCS})
 
 target_link_libraries (mokaQt controler-gmap controler gmapkernel)
 
-target_link_libraries(mokaQt ${QT_LIBRARIES} ${QT_QT3SUPPORT_LIBRARY})
-target_link_libraries(mokaQt ${QT_QTOPENGL_LIBRARY})
+#target_link_libraries(mokaQt ${QT_LIBRARIES} ${QT_QT3SUPPORT_LIBRARY})
+target_link_libraries(mokaQt Qt5::Widgets Qt5::Core Qt5::Gui)
+#target_link_libraries(mokaQt ${QT_QTOPENGL_LIBRARY})
 #-------------------------------------------------------------------------------

--- a/src/mokaQtIhm/CMakeLists.txt
+++ b/src/mokaQtIhm/CMakeLists.txt
@@ -29,11 +29,11 @@ INCLUDE_DIRECTORIES( ${CMAKE_BINARY_DIR} )
 QT5_WRAP_CPP(MOC_SRCS ${NEED_MOCS})
 QT5_ADD_RESOURCES(RESOURCES_SRCS ${QT_RESOURCES})
 #-------------------------------------------------------------------------------
-add_executable(mokaQt ${IHM_SRCS} ${MOC_SRCS} ${QT_RESOURCES} ${NEED_MOCS})
+add_executable(mokaQt ${IHM_SRCS} ${MOC_SRCS} ${RESOURCES_SRCS} ${NEED_MOCS})
 
 target_link_libraries (mokaQt controler-gmap controler gmapkernel)
-
+qt5_use_modules(mokaQt Core Gui Widgets OpenGL)
 #target_link_libraries(mokaQt ${QT_LIBRARIES} ${QT_QT3SUPPORT_LIBRARY})
-target_link_libraries(mokaQt Qt5::Widgets Qt5::Core Qt5::Gui)
+#target_link_libraries(mokaQt Qt5::Widgets Qt5::Core Qt5::Gui)
 #target_link_libraries(mokaQt ${QT_QTOPENGL_LIBRARY})
 #-------------------------------------------------------------------------------

--- a/src/mokaQtIhm/CMakeLists.txt
+++ b/src/mokaQtIhm/CMakeLists.txt
@@ -12,28 +12,16 @@ file(GLOB_RECURSE IHM_SRCS *.cc)
 file(GLOB_RECURSE NEED_MOCS *.qt.hh)
 set (QT_RESOURCES Icones/icones.qrc)
 #-------------------------------------------------------------------------------
-# We need QT4 library
-#SET( QT_USE_QT3SUPPORT TRUE )
-#SET( QT_USE_QTOPENGL  TRUE )
-#SET( QT_USE_QTGUI  TRUE )
+# We need QT5 library
+find_package(Qt5 COMPONENTS Core Widgets OpenGL REQUIRED)
 
-#FIND_PACKAGE(Qt4 REQUIRED)
-#INCLUDE(${QT_USE_FILE})
-
-find_package(Qt5Widgets)
-
-add_definitions(${QT_DEFINITIONS})
-include_directories (${QT_QTOPENGL_INCLUDE_DIR})
-INCLUDE_DIRECTORIES( ${CMAKE_BINARY_DIR} )
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 QT5_WRAP_CPP(MOC_SRCS ${NEED_MOCS})
 QT5_ADD_RESOURCES(RESOURCES_SRCS ${QT_RESOURCES})
 #-------------------------------------------------------------------------------
 add_executable(mokaQt ${IHM_SRCS} ${MOC_SRCS} ${RESOURCES_SRCS} ${NEED_MOCS})
 
-target_link_libraries (mokaQt controler-gmap controler gmapkernel)
-qt5_use_modules(mokaQt Core Gui Widgets OpenGL)
-#target_link_libraries(mokaQt ${QT_LIBRARIES} ${QT_QT3SUPPORT_LIBRARY})
-#target_link_libraries(mokaQt Qt5::Widgets Qt5::Core Qt5::Gui)
-#target_link_libraries(mokaQt ${QT_QTOPENGL_LIBRARY})
+target_link_libraries(mokaQt controler-gmap controler gmapkernel)
+target_link_libraries(mokaQt Qt5::Core Qt5::Widgets Qt5::OpenGL)
 #-------------------------------------------------------------------------------

--- a/src/mokaQtIhm/main.cc
+++ b/src/mokaQtIhm/main.cc
@@ -22,7 +22,7 @@
  */
 
 //******************************************************************************
-#include <QtGui/QApplication>
+#include <QtWidgets/QApplication>
 #include "window.qt.hh"
 #include <cstring>
 

--- a/src/mokaQtIhm/object-creations/creation-boutons.qt.cc
+++ b/src/mokaQtIhm/object-creations/creation-boutons.qt.cc
@@ -26,8 +26,6 @@
 #include "window.qt.hh"
 #include "HtmlEntities.hh"
 
-// #include <Qt3Support/Q3Accel>
-
 //***********************************
 // Constructeurs                    *
 //***********************************
@@ -52,20 +50,8 @@ BoutonsCreation::BoutonsCreation(CreationObjet * parent , QBoxLayout * layout)
 
    // Raccourcis claviers
 
-   /*  Q3Accel * Raccourci = new Q3Accel ( this ) ;
-       Raccourci -> insertItem ( QKeySequence ( Qt::Key_Space ) , 2 ) ;
-       Raccourci -> connectItem ( 2 , this ,
-                              SLOT ( cancel ( ) ) ) ;
-   */
-
    FReinitialiser->setShortcut(Qt::Key_Space);
    FOptions->setShortcut(Qt::CTRL + Qt::Key_P);
-
-   /*
-   Raccourci -> insertItem ( QKeySequence ( Qt::CTRL + Qt::Key_P ) , 3 ) ;
-   Raccourci -> connectItem ( 3 , this ,
-                              SLOT ( options ( ) ) ) ;
-   */
 
    // Mise en place des ecoutes
    QObject::connect(FReinitialiser , SIGNAL(clicked()) , this,

--- a/src/mokaQtIhm/object-creations/creation-boutons.qt.hh
+++ b/src/mokaQtIhm/object-creations/creation-boutons.qt.hh
@@ -31,8 +31,8 @@ class CreationObjet ;
 #include "controler-gmap.hh"
 
 //--------------------- Include QT --------------------
-#include <QtGui/QPushButton>
-#include <QtGui/QBoxLayout>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QBoxLayout>
 
 /*******************************************************/
 /* CLASSE BoutonsCreation                              */

--- a/src/mokaQtIhm/object-creations/creation-brin.qt.cc
+++ b/src/mokaQtIhm/object-creations/creation-brin.qt.cc
@@ -27,7 +27,7 @@
 #include "SpaceWidget.qt.hh"
 
 #include <QtGui/QPixmap>
-#include <QtGui/QLabel>
+#include <QtWidgets/QLabel>
 
 
 /*******************************************************************/

--- a/src/mokaQtIhm/object-creations/creation-cylindre.qt.cc
+++ b/src/mokaQtIhm/object-creations/creation-cylindre.qt.cc
@@ -26,7 +26,7 @@
 #include "HtmlEntities.hh"
 #include "SpaceWidget.qt.hh"
 
-#include <QtGui/QLabel>
+#include <QtWidgets/QLabel>
 
 
 /*******************************************************************/

--- a/src/mokaQtIhm/object-creations/creation-cylindre.qt.hh
+++ b/src/mokaQtIhm/object-creations/creation-cylindre.qt.hh
@@ -31,9 +31,9 @@ class Window ;
 #include "creation-objet.qt.hh"
 
 //--------------------- Include QT --------------------
-#include <QtGui/QMainWindow>
-#include <QtGui/QToolBar>
-#include <QtGui/QCheckBox>
+#include <QtWidgets/QMainWindow>
+#include <QtWidgets/QToolBar>
+#include <QtWidgets/QCheckBox>
 
 /*******************************************************************/
 /* CLASSE creationCylindre                                         */

--- a/src/mokaQtIhm/object-creations/creation-maillage.qt.cc
+++ b/src/mokaQtIhm/object-creations/creation-maillage.qt.cc
@@ -26,9 +26,9 @@
 #include "HtmlEntities.hh"
 #include "SpaceWidget.qt.hh"
 
-#include <QtGui/QLabel>
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QVBoxLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QVBoxLayout>
 
 
 /*******************************************************************/

--- a/src/mokaQtIhm/object-creations/creation-maillage.qt.hh
+++ b/src/mokaQtIhm/object-creations/creation-maillage.qt.hh
@@ -31,8 +31,8 @@ class Window ;
 #include "creation-objet.qt.hh"
 
 //--------------------- Include QT --------------------
-#include <QtGui/QCheckBox>
-#include <QtGui/QComboBox>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QComboBox>
 
 /*******************************************************************/
 /* CLASSE creationMaillage                                         */

--- a/src/mokaQtIhm/object-creations/creation-options.qt.cc
+++ b/src/mokaQtIhm/object-creations/creation-options.qt.cc
@@ -25,9 +25,10 @@
 #include "window.qt.hh"
 
 #include <QtGui/QPixmap>
-#include <QtGui/QLabel>
-#include <QtGui/QBoxLayout>
-#include <Qt3Support/Q3Accel>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QBoxLayout>
+#include <QtWidgets/QShortcut>
+//#include <Qt3Support/Q3Accel>
 
 static const char * const coordLabels [ 3 ] =
 {
@@ -217,9 +218,10 @@ BoitePositionnement ::  BoitePositionnement(CreationObjet * lien ,
                       SIGNAL(clicked()) , this ,
                       SLOT(hide())) ;
 
-   Q3Accel * Raccourci = new Q3Accel(this) ;
-   Raccourci -> insertItem(QKeySequence(Qt::Key_Space) , 2) ;
-   Raccourci -> connectItem(2 , FLien , SLOT(cancel())) ;
+   QShortcut* NewShortcut = new QShortcut(QKeySequence ( Qt::Key_Space ), this, SLOT(cancel()));
+//   Q3Accel * Raccourci = new Q3Accel(this) ;
+//   Raccourci -> insertItem(QKeySequence(Qt::Key_Space) , 2) ;
+//   Raccourci -> connectItem(2 , FLien , SLOT(cancel())) ;
 }
 
 //*******************************************

--- a/src/mokaQtIhm/object-creations/creation-options.qt.cc
+++ b/src/mokaQtIhm/object-creations/creation-options.qt.cc
@@ -218,10 +218,9 @@ BoitePositionnement ::  BoitePositionnement(CreationObjet * lien ,
                       SIGNAL(clicked()) , this ,
                       SLOT(hide())) ;
 
-   QShortcut* NewShortcut = new QShortcut(QKeySequence ( Qt::Key_Space ), this, SLOT(cancel()));
-//   Q3Accel * Raccourci = new Q3Accel(this) ;
-//   Raccourci -> insertItem(QKeySequence(Qt::Key_Space) , 2) ;
-//   Raccourci -> connectItem(2 , FLien , SLOT(cancel())) ;
+   QShortcut* keySpace = new QShortcut(this);
+   keySpace->setKey(QKeySequence ( Qt::Key_Space ));
+   connect(keySpace, SIGNAL(activated()), FLien, SLOT(cancel()));
 }
 
 //*******************************************

--- a/src/mokaQtIhm/object-creations/creation-options.qt.cc
+++ b/src/mokaQtIhm/object-creations/creation-options.qt.cc
@@ -28,7 +28,6 @@
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QBoxLayout>
 #include <QtWidgets/QShortcut>
-//#include <Qt3Support/Q3Accel>
 
 static const char * const coordLabels [ 3 ] =
 {

--- a/src/mokaQtIhm/object-creations/creation-options.qt.hh
+++ b/src/mokaQtIhm/object-creations/creation-options.qt.hh
@@ -31,10 +31,10 @@ class Window ;
 class CreationObjet ;
 
 //-------------------- Include QT --------------------
-#include <QtGui/QPushButton>
-#include <QtGui/QLabel>
-#include <QtGui/QToolBar>
-#include <QtGui/QDialog>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QToolBar>
+#include <QtWidgets/QDialog>
 
 /*****************************************************/
 /* CLASSE BoitePositionnement                        */

--- a/src/mokaQtIhm/object-creations/creation-polygone.qt.cc
+++ b/src/mokaQtIhm/object-creations/creation-polygone.qt.cc
@@ -26,7 +26,7 @@
 #include "HtmlEntities.hh"
 #include "SpaceWidget.qt.hh"
 
-#include <QtGui/QLabel>
+#include <QtWidgets/QLabel>
 
 /*******************************************************************/
 /* CLASSE CreationPolygone                                         */

--- a/src/mokaQtIhm/object-creations/creation-pyramide.qt.cc
+++ b/src/mokaQtIhm/object-creations/creation-pyramide.qt.cc
@@ -26,7 +26,7 @@
 #include "HtmlEntities.hh"
 #include "SpaceWidget.qt.hh"
 
-#include <QtGui/QLabel>
+#include <QtWidgets/QLabel>
 
 /*******************************************************************/
 /* CLASSE  creationPyramide                                        */

--- a/src/mokaQtIhm/object-creations/creation-pyramide.qt.hh
+++ b/src/mokaQtIhm/object-creations/creation-pyramide.qt.hh
@@ -30,7 +30,7 @@ class Window ;
 
 
 //--------------------- Include QT --------------------
-#include <QtGui/QCheckBox>
+#include <QtWidgets/QCheckBox>
 
 /*******************************************************************/
 /* CLASSE CreationPyramide                                         */

--- a/src/mokaQtIhm/object-creations/creation-sphere.qt.cc
+++ b/src/mokaQtIhm/object-creations/creation-sphere.qt.cc
@@ -26,7 +26,7 @@
 #include "HtmlEntities.hh"
 #include "SpaceWidget.qt.hh"
 
-#include <QtGui/QLabel>
+#include <QtWidgets/QLabel>
 
 /*******************************************************************/
 /* CLASSE creationSphere                                           */

--- a/src/mokaQtIhm/object-creations/creation-tore.qt.cc
+++ b/src/mokaQtIhm/object-creations/creation-tore.qt.cc
@@ -26,8 +26,8 @@
 #include "HtmlEntities.hh"
 #include "SpaceWidget.qt.hh"
 
-#include <QtGui/QLabel>
-#include <QtGui/QHBoxLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QHBoxLayout>
 
 /*******************************************************************/
 /* CLASSE  creationTore                                        */

--- a/src/mokaQtIhm/object-creations/creation-tore.qt.hh
+++ b/src/mokaQtIhm/object-creations/creation-tore.qt.hh
@@ -29,7 +29,7 @@
 class Window ;
 
 //--------------------- Include QT --------------------
-#include <QtGui/QSlider>
+#include <QtWidgets/QSlider>
 
 /*******************************************************************/
 /* CLASSE CreationTore                                             */

--- a/src/mokaQtIhm/object-operations/dialog-homothetie.qt.cc
+++ b/src/mokaQtIhm/object-operations/dialog-homothetie.qt.cc
@@ -27,8 +27,8 @@
 #include "SpaceWidget.qt.hh"
 
 #include <QtGui/QPixmap>
-#include <QtGui/QLabel>
-#include <QtGui/QBoxLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QBoxLayout>
 
 // Constructeur
 //-------------

--- a/src/mokaQtIhm/object-operations/dialog-homothetie.qt.hh
+++ b/src/mokaQtIhm/object-operations/dialog-homothetie.qt.hh
@@ -28,8 +28,8 @@
 #include "dialog-operations.qt.hh"
 
 //--------------------- Include QT --------------------
-#include <QtGui/QComboBox>
-#include <QtGui/QLabel>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QLabel>
 
 class Window ;
 

--- a/src/mokaQtIhm/object-operations/dialog-operations.qt.cc
+++ b/src/mokaQtIhm/object-operations/dialog-operations.qt.cc
@@ -26,7 +26,7 @@
 #include "HtmlEntities.hh"
 #include "SpaceWidget.qt.hh"
 
-#include <QtGui/QLabel>
+#include <QtWidgets/QLabel>
 
 /*******************************************************************/
 /* CLASSE champsOperations                                         */

--- a/src/mokaQtIhm/object-operations/dialog-operations.qt.hh
+++ b/src/mokaQtIhm/object-operations/dialog-operations.qt.hh
@@ -30,11 +30,11 @@
 #include "dialog-types.hh"
 
 //--------------------- Include QT --------------------
-#include <QtGui/QCheckBox>
-#include <QtGui/QPushButton>
-#include <QtGui/QLabel>
-#include <QtGui/QToolBar>
-#include <QtGui/QBoxLayout>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QToolBar>
+#include <QtWidgets/QBoxLayout>
 
 
 /*******************************************************************/

--- a/src/mokaQtIhm/object-operations/dialog-rotation.qt.cc
+++ b/src/mokaQtIhm/object-operations/dialog-rotation.qt.cc
@@ -27,9 +27,9 @@
 #include "SpaceWidget.qt.hh"
 
 #include <QtGui/QPixmap>
-#include <QtGui/QLabel>
-#include <QtGui/QBoxLayout>
-#include <QtGui/QGridLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QBoxLayout>
+#include <QtWidgets/QGridLayout>
 
 // Constructeur
 //-------------

--- a/src/mokaQtIhm/object-operations/operation-chanfreinage.qt.cc
+++ b/src/mokaQtIhm/object-operations/operation-chanfreinage.qt.cc
@@ -25,9 +25,10 @@
 #include "window.qt.hh"
 #include "HtmlEntities.hh"
 
-#include <QtGui/QLabel>
-#include <QtGui/QBoxLayout>
-#include <Qt3Support/Q3Accel>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QBoxLayout>
+#include <QtWidgets/QShortcut>
+//#include <Qt3Support/Q3Accel>
 
 
 // Constructeur
@@ -43,11 +44,11 @@ OperationChanfreinage :: OperationChanfreinage ( Window * parent )
 
   // Definition des raccourcis claviers
 
-  Q3Accel * Raccourci = new Q3Accel ( this ) ;
-  Raccourci -> insertItem ( QKeySequence ( Qt :: Key_Space ) , 9 ) ;
-  Raccourci -> connectItem ( 9 , FParent ,
-			     SLOT ( callbackHideAllWindow ( ) ) )  ;
-
+//  Q3Accel * Raccourci = new Q3Accel ( this ) ;
+//  Raccourci -> insertItem ( QKeySequence ( Qt :: Key_Space ) , 9 ) ;
+//  Raccourci -> connectItem ( 9 , FParent ,
+//			     SLOT ( callbackHideAllWindow ( ) ) )  ;
+  QShortcut* NewShortcut = new QShortcut(QKeySequence ( Qt :: Key_Space ), this, SLOT ( callbackHideAllWindow ( ) ) );
 
   QBoxLayout * placement = new QBoxLayout ( QBoxLayout::TopToBottom, this ) ; 
   

--- a/src/mokaQtIhm/object-operations/operation-chanfreinage.qt.cc
+++ b/src/mokaQtIhm/object-operations/operation-chanfreinage.qt.cc
@@ -28,8 +28,6 @@
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QBoxLayout>
 #include <QtWidgets/QShortcut>
-//#include <Qt3Support/Q3Accel>
-
 
 // Constructeur
 //-------------
@@ -44,11 +42,9 @@ OperationChanfreinage :: OperationChanfreinage ( Window * parent )
 
   // Definition des raccourcis claviers
 
-//  Q3Accel * Raccourci = new Q3Accel ( this ) ;
-//  Raccourci -> insertItem ( QKeySequence ( Qt :: Key_Space ) , 9 ) ;
-//  Raccourci -> connectItem ( 9 , FParent ,
-//			     SLOT ( callbackHideAllWindow ( ) ) )  ;
-  QShortcut* NewShortcut = new QShortcut(QKeySequence ( Qt :: Key_Space ), this, SLOT ( callbackHideAllWindow ( ) ) );
+  QShortcut* keySpace = new QShortcut(this);
+  keySpace->setKey(QKeySequence ( Qt :: Key_Space ));
+  connect(keySpace, SIGNAL(activated()), FParent, SLOT ( callbackHideAllWindow ( ) ) );
 
   QBoxLayout * placement = new QBoxLayout ( QBoxLayout::TopToBottom, this ) ; 
   

--- a/src/mokaQtIhm/object-operations/operation-chanfreinage.qt.hh
+++ b/src/mokaQtIhm/object-operations/operation-chanfreinage.qt.hh
@@ -29,9 +29,9 @@
 #include "floatSpinBox.qt.hh"
 
 //--------------------- Include QT --------------------
-#include <QtGui/QPushButton>
-#include <QtGui/QLabel>
-#include <QtGui/QDialog>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QDialog>
 
 
 class Window ;

--- a/src/mokaQtIhm/object-options/options-affichage.qt.cc
+++ b/src/mokaQtIhm/object-options/options-affichage.qt.cc
@@ -25,10 +25,10 @@
 #include "window.qt.hh"
 #include "HtmlEntities.hh"
 
-#include <QtGui/QGridLayout>
-#include <QtGui/QLabel>
-#include <QtGui/QVBoxLayout>
-#include <QtGui/QHBoxLayout>
+#include <QtWidgets/QGridLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QVBoxLayout>
+#include <QtWidgets/QHBoxLayout>
 
 
 // Constructeur

--- a/src/mokaQtIhm/object-options/options-affichage.qt.hh
+++ b/src/mokaQtIhm/object-options/options-affichage.qt.hh
@@ -29,12 +29,12 @@
 #include "options-vue.qt.hh"
 
 //--------------------- Include QT --------------------
-#include <QtGui/QSpinBox>
-#include <QtGui/QCheckBox>
-#include <QtGui/QLabel>
-#include <QtGui/QRadioButton>
-#include <QtGui/QTabWidget>
-#include <QtGui/QGroupBox>
+#include <QtWidgets/QSpinBox>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QRadioButton>
+#include <QtWidgets/QTabWidget>
+#include <QtWidgets/QGroupBox>
 
 class Window ;
 

--- a/src/mokaQtIhm/object-options/options-carac.qt.cc
+++ b/src/mokaQtIhm/object-options/options-carac.qt.cc
@@ -25,10 +25,11 @@
 #include "window.qt.hh"
 #include "HtmlEntities.hh"
 
-#include <QtGui/QGridLayout>
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QLabel>
-#include <Qt3Support/Q3Accel>
+#include <QtWidgets/QGridLayout>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QShortcut>
+//#include <Qt3Support/Q3Accel>
 
 
 // Constructeur
@@ -44,9 +45,10 @@ OptionsCarac :: OptionsCarac(Window * parent)
 
    // Definition du raccourci
 
-   Q3Accel * Raccourci = new Q3Accel(this) ;
-   Raccourci -> insertItem(QKeySequence(Qt :: Key_Space) , 9) ;
-   Raccourci -> connectItem(9 , this , SLOT(close()))  ;
+//   Q3Accel * Raccourci = new Q3Accel(this) ;
+   QShortcut * AShortcut = new QShortcut(QKeySequence(Qt :: Key_Space), this, SLOT(close()));
+//   Raccourci -> insertItem(QKeySequence(Qt :: Key_Space) , 9) ;
+//   Raccourci -> connectItem(9 , this , SLOT(close()))  ;
 
    QHBoxLayout * placement = new QHBoxLayout(this) ;
 

--- a/src/mokaQtIhm/object-options/options-carac.qt.cc
+++ b/src/mokaQtIhm/object-options/options-carac.qt.cc
@@ -29,8 +29,6 @@
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QShortcut>
-//#include <Qt3Support/Q3Accel>
-
 
 // Constructeur
 //-------------
@@ -44,11 +42,7 @@ OptionsCarac :: OptionsCarac(Window * parent)
    setWindowTitle("Topological characteristics") ;
 
    // Definition du raccourci
-
-//   Q3Accel * Raccourci = new Q3Accel(this) ;
-   QShortcut * AShortcut = new QShortcut(QKeySequence(Qt :: Key_Space), this, SLOT(close()));
-//   Raccourci -> insertItem(QKeySequence(Qt :: Key_Space) , 9) ;
-//   Raccourci -> connectItem(9 , this , SLOT(close()))  ;
+   new QShortcut(QKeySequence(Qt :: Key_Space), this, SLOT(close()));
 
    QHBoxLayout * placement = new QHBoxLayout(this) ;
 

--- a/src/mokaQtIhm/object-options/options-carac.qt.hh
+++ b/src/mokaQtIhm/object-options/options-carac.qt.hh
@@ -34,9 +34,9 @@
 //--------------------- Include QT --------------------
 
 #include <QtOpenGL/QGLWidget>
-#include <QtGui/QLabel>
-#include <QtGui/QDialog>
-#include <QtGui/QGroupBox>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QDialog>
+#include <QtWidgets/QGroupBox>
 
 
 class Window ;

--- a/src/mokaQtIhm/object-options/options-couleurs.qt.cc
+++ b/src/mokaQtIhm/object-options/options-couleurs.qt.cc
@@ -27,8 +27,9 @@
 #include "HtmlEntities.hh"
 
 #include <QtGui/QPixmap>
-#include <QtGui/QColorDialog>
-#include <Qt3Support/Q3Accel>
+#include <QtWidgets/QColorDialog>
+#include <QtWidgets/QShortcut>
+//#include <Qt3Support/Q3Accel>
 
 //**********************************************************
 // Elements dont on peut modifier la couleur
@@ -105,9 +106,9 @@ OptionCouleurs :: OptionCouleurs(Window * parent)
    QObject :: connect(FModifiables , SIGNAL(activated(int)) , this ,
                       SLOT(changeColor())) ;
 
-   Q3Accel * Raccourci = new Q3Accel(this) ;
-   Raccourci -> insertItem(QKeySequence(Qt::Key_Space) , 2) ;
-   Raccourci -> connectItem(2 , this , SLOT(close())) ;
+//   Q3Accel * Raccourci = new Q3Accel(this) ;
+//   Raccourci -> insertItem(QKeySequence(Qt::Key_Space) , 2) ;
+//   Raccourci -> connectItem(2 , this , SLOT(close())) ;
 
    addWidget(new SpaceWidget(15, 1));
    addWidget(FModifiables);

--- a/src/mokaQtIhm/object-options/options-couleurs.qt.cc
+++ b/src/mokaQtIhm/object-options/options-couleurs.qt.cc
@@ -106,9 +106,9 @@ OptionCouleurs :: OptionCouleurs(Window * parent)
    QObject :: connect(FModifiables , SIGNAL(activated(int)) , this ,
                       SLOT(changeColor())) ;
 
-//   Q3Accel * Raccourci = new Q3Accel(this) ;
-//   Raccourci -> insertItem(QKeySequence(Qt::Key_Space) , 2) ;
-//   Raccourci -> connectItem(2 , this , SLOT(close())) ;
+   QShortcut* keySpace = new QShortcut(this);
+   keySpace->setKey(QKeySequence ( Qt::Key_Space ));
+   connect(keySpace, SIGNAL(activated()), this, SLOT(close()));
 
    addWidget(new SpaceWidget(15, 1));
    addWidget(FModifiables);

--- a/src/mokaQtIhm/object-options/options-couleurs.qt.cc
+++ b/src/mokaQtIhm/object-options/options-couleurs.qt.cc
@@ -29,7 +29,6 @@
 #include <QtGui/QPixmap>
 #include <QtWidgets/QColorDialog>
 #include <QtWidgets/QShortcut>
-//#include <Qt3Support/Q3Accel>
 
 //**********************************************************
 // Elements dont on peut modifier la couleur

--- a/src/mokaQtIhm/object-options/options-couleurs.qt.hh
+++ b/src/mokaQtIhm/object-options/options-couleurs.qt.hh
@@ -30,9 +30,9 @@
 #include "floatSpinBox.qt.hh"
 
 //--------------------- Include QT --------------------
-#include <QtGui/QComboBox>
-#include <QtGui/QPushButton>
-#include <QtGui/QToolBar>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QToolBar>
 
 
 

--- a/src/mokaQtIhm/object-options/options-divers.qt.cc
+++ b/src/mokaQtIhm/object-options/options-divers.qt.cc
@@ -25,8 +25,8 @@
 #include "window.qt.hh"
 #include "HtmlEntities.hh"
 
-#include <QtGui/QVBoxLayout>
-#include <QtGui/QLabel>
+#include <QtWidgets/QVBoxLayout>
+#include <QtWidgets/QLabel>
 
 // Constructeur
 //-------------

--- a/src/mokaQtIhm/object-options/options-divers.qt.hh
+++ b/src/mokaQtIhm/object-options/options-divers.qt.hh
@@ -29,11 +29,11 @@
 #include "floatSpinBox.qt.hh"
 
 //--------------------- Include QT --------------------
-#include <QtGui/QCheckBox>
-#include <QtGui/QComboBox>
-#include <QtGui/QLabel>
-#include <QtGui/QTabWidget>
-#include <QtGui/QGroupBox>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QTabWidget>
+#include <QtWidgets/QGroupBox>
 
 
 

--- a/src/mokaQtIhm/object-options/options-extrusion.qt.cc
+++ b/src/mokaQtIhm/object-options/options-extrusion.qt.cc
@@ -25,8 +25,8 @@
 #include "window.qt.hh"
 #include "HtmlEntities.hh"
 
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QLabel>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QLabel>
 
 // Constructeur
 //-------------

--- a/src/mokaQtIhm/object-options/options-extrusion.qt.hh
+++ b/src/mokaQtIhm/object-options/options-extrusion.qt.hh
@@ -29,11 +29,11 @@
 #include "floatSpinBox.qt.hh"
 
 //--------------------- Include QT --------------------
-#include <QtGui/QCheckBox>
-#include <QtGui/QComboBox>
-#include <QtGui/QLabel>
-#include <QtGui/QTabWidget>
-#include <QtGui/QGroupBox>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QTabWidget>
+#include <QtWidgets/QGroupBox>
 
 
 

--- a/src/mokaQtIhm/object-options/options-frame.qt.cc
+++ b/src/mokaQtIhm/object-options/options-frame.qt.cc
@@ -25,9 +25,9 @@
 #include "window.qt.hh"
 #include "HtmlEntities.hh"
 
-#include <Qt3Support/Q3Accel>
-#include <QtGui/QVBoxLayout>
-
+//#include <Qt3Support/Q3Accel>
+#include <QtWidgets/QVBoxLayout>
+#include <QtWidgets/QShortcut>
 
 // Constructeur
 //-------------
@@ -63,49 +63,49 @@ OptionsFrame :: OptionsFrame ( Window * parent )
   main_tab -> addTab ( FDivers , "&Misc" ) ;
 
   // Definition des raccourcis
-  Q3Accel * Raccourci = new Q3Accel ( this ) ;
+//  Q3Accel * Raccourci = new Q3Accel ( this ) ;
 
-  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F2 ) , 2 ) ;
-  Raccourci -> connectItem ( 2 , this , SLOT ( callbackShowAffichage ( ) ) ) ;
+//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F2 ) , 2 ) ;
+//  Raccourci -> connectItem ( 2 , this , SLOT ( callbackShowAffichage ( ) ) ) ;
 
-  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F3 ) , 3 ) ;
-  Raccourci -> connectItem ( 3 , this , SLOT ( callbackShowVue ( ) ) ) ;
+//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F3 ) , 3 ) ;
+//  Raccourci -> connectItem ( 3 , this , SLOT ( callbackShowVue ( ) ) ) ;
 
-  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F4 ) , 4 ) ;
-  Raccourci -> connectItem ( 4 , this , SLOT ( callbackShowPonderation ( ) ) ) ;
+//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F4 ) , 4 ) ;
+//  Raccourci -> connectItem ( 4 , this , SLOT ( callbackShowPonderation ( ) ) ) ;
 
-  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F5 ) , 5 ) ;
-  Raccourci -> connectItem ( 5 , this , SLOT ( callbackShowExtrusion ( ) ) ) ;
+//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F5 ) , 5 ) ;
+//  Raccourci -> connectItem ( 5 , this , SLOT ( callbackShowExtrusion ( ) ) ) ;
 
-  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F6 ) , 6 ) ;
-  Raccourci -> connectItem ( 6 , this , SLOT ( callbackShowInterpolation()));
+//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F6 ) , 6 ) ;
+//  Raccourci -> connectItem ( 6 , this , SLOT ( callbackShowInterpolation()));
 
-  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F7 ) , 7 ) ;
-  Raccourci->connectItem(7, this, SLOT(callbackShowDivers()));
+//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F7 ) , 7 ) ;
+//  Raccourci->connectItem(7, this, SLOT(callbackShowDivers()));
   
-//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F8 ) , 15 ) ;
-//  Raccourci -> connectItem ( 15 , this , SLOT ( callbackShowDivers ( ) ) ) ;
+////  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F8 ) , 15 ) ;
+////  Raccourci -> connectItem ( 15 , this , SLOT ( callbackShowDivers ( ) ) ) ;
 
-  Raccourci -> insertItem ( QKeySequence ( "Alt+F9" ) , 8 ) ;
-  Raccourci -> connectItem ( 8 , this , SLOT ( callbackToggleNormal ( ) ) ) ;
+//  Raccourci -> insertItem ( QKeySequence ( "Alt+F9" ) , 8 ) ;
+//  Raccourci -> connectItem ( 8 , this , SLOT ( callbackToggleNormal ( ) ) ) ;
 
-  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F9 ) , 9 ) ;
-  Raccourci -> connectItem ( 9 , this , SLOT ( callbackToggleSews ( ) ) ) ;
+//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F9 ) , 9 ) ;
+//  Raccourci -> connectItem ( 9 , this , SLOT ( callbackToggleSews ( ) ) ) ;
 
-  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F10 ) , 10 ) ;
-  Raccourci -> connectItem ( 10 , this , SLOT ( callbackToggleVertices ( ) ) ) ;
+//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F10 ) , 10 ) ;
+//  Raccourci -> connectItem ( 10 , this , SLOT ( callbackToggleVertices ( ) ) ) ;
 
-  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F11 ) , 11 ) ;
-  Raccourci -> connectItem ( 11 , this , SLOT ( callbackToggleFaces ( ) ) ) ;
+//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F11 ) , 11 ) ;
+//  Raccourci -> connectItem ( 11 , this , SLOT ( callbackToggleFaces ( ) ) ) ;
 
-  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F12 ) , 12 ) ;
-  Raccourci -> connectItem ( 12 , this , SLOT ( callbackToggleGrille ( ) ) ) ;
+//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F12 ) , 12 ) ;
+//  Raccourci -> connectItem ( 12 , this , SLOT ( callbackToggleGrille ( ) ) ) ;
 
-  Raccourci->insertItem ( QKeySequence ( Qt :: Key_Space ) , 13 ) ;
-  Raccourci->connectItem(13, parent, SLOT (callbackHideAllWindow()));
+//  Raccourci->insertItem ( QKeySequence ( Qt :: Key_Space ) , 13 ) ;
+//  Raccourci->connectItem(13, parent, SLOT (callbackHideAllWindow()));
 
-  Raccourci -> insertItem ( QKeySequence ( "Alt+F11" ) , 14 ) ;
-  Raccourci -> connectItem ( 14 , this , SLOT (callbackTournerButton() ))  ;
+//  Raccourci -> insertItem ( QKeySequence ( "Alt+F11" ) , 14 ) ;
+//  Raccourci -> connectItem ( 14 , this , SLOT (callbackTournerButton() ))  ;
   
   connect(main_tab,SIGNAL(currentChanged(int)),this,SLOT(updateTab(int)));
   

--- a/src/mokaQtIhm/object-options/options-frame.qt.cc
+++ b/src/mokaQtIhm/object-options/options-frame.qt.cc
@@ -25,7 +25,6 @@
 #include "window.qt.hh"
 #include "HtmlEntities.hh"
 
-//#include <Qt3Support/Q3Accel>
 #include <QtWidgets/QVBoxLayout>
 #include <QtWidgets/QShortcut>
 
@@ -62,50 +61,26 @@ OptionsFrame :: OptionsFrame ( Window * parent )
   FDivers = new OptionsDivers ( parent , main_tab ) ;
   main_tab -> addTab ( FDivers , "&Misc" ) ;
 
-  // Definition des raccourcis
-//  Q3Accel * Raccourci = new Q3Accel ( this ) ;
+  // Definition of shortcuts
+  new QShortcut(QKeySequence ( Qt::Key_F2 ), this, SLOT(callbackShowAffichage()));
+  new QShortcut(QKeySequence ( Qt::Key_F3 ), this, SLOT(callbackShowVue()));
+  new QShortcut(QKeySequence ( Qt::Key_F4 ), this, SLOT(callbackShowPonderation()));
+  new QShortcut(QKeySequence ( Qt::Key_F5 ), this, SLOT(callbackShowExtrusion()));
+  new QShortcut(QKeySequence ( Qt::Key_F6 ), this, SLOT(callbackShowInterpolation()));
+  new QShortcut(QKeySequence ( Qt::Key_F7 ), this, SLOT(callbackShowDivers()));
+  new QShortcut(QKeySequence ( Qt::Key_F8 ), this, SLOT(callbackShowDivers()));
+  new QShortcut(QKeySequence ( Qt::Key_F9 ), this, SLOT(callbackToggleSews()));
+  new QShortcut(QKeySequence ( "Alt+F9" ), this, SLOT(callbackToggleNormal()));
+  new QShortcut(QKeySequence ( Qt::Key_F9 ), this, SLOT(callbackToggleSews()));
+  new QShortcut(QKeySequence ( Qt::Key_F10 ), this, SLOT(callbackToggleVertices()));
+  new QShortcut(QKeySequence ( Qt::Key_F11 ), this, SLOT(callbackToggleFaces()));
+  new QShortcut(QKeySequence ( Qt::Key_F12 ), this, SLOT(callbackToggleGrille()));
 
-//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F2 ) , 2 ) ;
-//  Raccourci -> connectItem ( 2 , this , SLOT ( callbackShowAffichage ( ) ) ) ;
+  QShortcut* keySpace = new QShortcut(this);
+  keySpace->setKey(QKeySequence ( Qt::Key_Space ));
+  connect(keySpace, SIGNAL(activated()), parent, SLOT(callbackHideAllWindow()));
 
-//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F3 ) , 3 ) ;
-//  Raccourci -> connectItem ( 3 , this , SLOT ( callbackShowVue ( ) ) ) ;
-
-//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F4 ) , 4 ) ;
-//  Raccourci -> connectItem ( 4 , this , SLOT ( callbackShowPonderation ( ) ) ) ;
-
-//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F5 ) , 5 ) ;
-//  Raccourci -> connectItem ( 5 , this , SLOT ( callbackShowExtrusion ( ) ) ) ;
-
-//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F6 ) , 6 ) ;
-//  Raccourci -> connectItem ( 6 , this , SLOT ( callbackShowInterpolation()));
-
-//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F7 ) , 7 ) ;
-//  Raccourci->connectItem(7, this, SLOT(callbackShowDivers()));
-  
-////  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F8 ) , 15 ) ;
-////  Raccourci -> connectItem ( 15 , this , SLOT ( callbackShowDivers ( ) ) ) ;
-
-//  Raccourci -> insertItem ( QKeySequence ( "Alt+F9" ) , 8 ) ;
-//  Raccourci -> connectItem ( 8 , this , SLOT ( callbackToggleNormal ( ) ) ) ;
-
-//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F9 ) , 9 ) ;
-//  Raccourci -> connectItem ( 9 , this , SLOT ( callbackToggleSews ( ) ) ) ;
-
-//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F10 ) , 10 ) ;
-//  Raccourci -> connectItem ( 10 , this , SLOT ( callbackToggleVertices ( ) ) ) ;
-
-//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F11 ) , 11 ) ;
-//  Raccourci -> connectItem ( 11 , this , SLOT ( callbackToggleFaces ( ) ) ) ;
-
-//  Raccourci -> insertItem ( QKeySequence ( Qt::Key_F12 ) , 12 ) ;
-//  Raccourci -> connectItem ( 12 , this , SLOT ( callbackToggleGrille ( ) ) ) ;
-
-//  Raccourci->insertItem ( QKeySequence ( Qt :: Key_Space ) , 13 ) ;
-//  Raccourci->connectItem(13, parent, SLOT (callbackHideAllWindow()));
-
-//  Raccourci -> insertItem ( QKeySequence ( "Alt+F11" ) , 14 ) ;
-//  Raccourci -> connectItem ( 14 , this , SLOT (callbackTournerButton() ))  ;
+  new QShortcut(QKeySequence ( "Alt+F11" ), this, SLOT(callbackTournerButton()));
   
   connect(main_tab,SIGNAL(currentChanged(int)),this,SLOT(updateTab(int)));
   

--- a/src/mokaQtIhm/object-options/options-frame.qt.hh
+++ b/src/mokaQtIhm/object-options/options-frame.qt.hh
@@ -35,9 +35,9 @@
 
 
 //--------------------- Include QT --------------------
-#include <QtGui/QDialog>
-#include <QtGui/QPushButton>
-#include <QtGui/QTabWidget>
+#include <QtWidgets/QDialog>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QTabWidget>
 
 
 

--- a/src/mokaQtIhm/object-options/options-interpolation.qt.cc
+++ b/src/mokaQtIhm/object-options/options-interpolation.qt.cc
@@ -25,8 +25,8 @@
 #include "window.qt.hh"
 #include "HtmlEntities.hh"
 
-#include <QtGui/QLabel>
-#include <QtGui/QBoxLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QBoxLayout>
 
 // Constructeur
 //-------------

--- a/src/mokaQtIhm/object-options/options-interpolation.qt.hh
+++ b/src/mokaQtIhm/object-options/options-interpolation.qt.hh
@@ -28,12 +28,12 @@
 #include "controler-gmap.hh"
 
 //--------------------- Include QT --------------------
-#include <QtGui/QSpinBox>
-#include <QtGui/QCheckBox>
-#include <QtGui/QComboBox>
-#include <QtGui/QLabel>
-#include <QtGui/QTabWidget>
-#include <QtGui/QGroupBox>
+#include <QtWidgets/QSpinBox>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QTabWidget>
+#include <QtWidgets/QGroupBox>
 
 
 class Window ;

--- a/src/mokaQtIhm/object-options/options-ponderation.qt.cc
+++ b/src/mokaQtIhm/object-options/options-ponderation.qt.cc
@@ -25,8 +25,8 @@
 #include "window.qt.hh"
 #include "HtmlEntities.hh"
 
-#include <QtGui/QLabel>
-#include <QtGui/QVBoxLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QVBoxLayout>
 
 // Constructeur
 //-------------

--- a/src/mokaQtIhm/object-options/options-ponderation.qt.hh
+++ b/src/mokaQtIhm/object-options/options-ponderation.qt.hh
@@ -29,12 +29,12 @@
 #include "floatSpinBox.qt.hh"
 
 //--------------------- Include QT --------------------
-#include <QtGui/QPushButton>
-#include <QtGui/QCheckBox>
-#include <QtGui/QComboBox>
-#include <QtGui/QLabel>
-#include <QtGui/QTabWidget>
-#include <QtGui/QGroupBox>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QTabWidget>
+#include <QtWidgets/QGroupBox>
 
 
 

--- a/src/mokaQtIhm/object-options/options-surfacic-homology.qt.cc
+++ b/src/mokaQtIhm/object-options/options-surfacic-homology.qt.cc
@@ -26,10 +26,11 @@
 #include "HtmlEntities.hh"
 #include "compute-homology.hh"
 
-#include <QtGui/QGridLayout>
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QLabel>
-#include <Qt3Support/Q3Accel>
+#include <QtWidgets/QGridLayout>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QShortcut>
+//#include <Qt3Support/Q3Accel>
 
 #ifndef _WINDOWS
 #include "chrono.hh"
@@ -49,9 +50,10 @@ OptionsSurfacicHomology :: OptionsSurfacicHomology(Window * parent) :
 
    // Definition du raccourci
 
-   Q3Accel * Raccourci = new Q3Accel(this) ;
-   Raccourci -> insertItem(QKeySequence(Qt :: Key_Space) , 9) ;
-   Raccourci -> connectItem(9 , this , SLOT(close()))  ;
+   QShortcut* newShortcut = new QShortcut(QKeySequence(Qt :: Key_Space), this, SLOT(close()));
+//   Q3Accel * Raccourci = new Q3Accel(this) ;
+//   Raccourci -> insertItem(QKeySequence(Qt :: Key_Space) , 9) ;
+//   Raccourci -> connectItem(9 , this , SLOT(close()))  ;
 
    QVBoxLayout * placement = new QVBoxLayout(this) ;
 

--- a/src/mokaQtIhm/object-options/options-surfacic-homology.qt.cc
+++ b/src/mokaQtIhm/object-options/options-surfacic-homology.qt.cc
@@ -30,7 +30,6 @@
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QShortcut>
-//#include <Qt3Support/Q3Accel>
 
 #ifndef _WINDOWS
 #include "chrono.hh"
@@ -50,10 +49,7 @@ OptionsSurfacicHomology :: OptionsSurfacicHomology(Window * parent) :
 
    // Definition du raccourci
 
-   QShortcut* newShortcut = new QShortcut(QKeySequence(Qt :: Key_Space), this, SLOT(close()));
-//   Q3Accel * Raccourci = new Q3Accel(this) ;
-//   Raccourci -> insertItem(QKeySequence(Qt :: Key_Space) , 9) ;
-//   Raccourci -> connectItem(9 , this , SLOT(close()))  ;
+   new QShortcut(QKeySequence(Qt :: Key_Space), this, SLOT(close()));
 
    QVBoxLayout * placement = new QVBoxLayout(this) ;
 

--- a/src/mokaQtIhm/object-options/options-surfacic-homology.qt.hh
+++ b/src/mokaQtIhm/object-options/options-surfacic-homology.qt.hh
@@ -34,9 +34,9 @@
 //--------------------- Include QT --------------------
 
 #include <QtOpenGL/QGLWidget>
-#include <QtGui/QLabel>
-#include <QtGui/QDialog>
-#include <QtGui/QGroupBox>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QDialog>
+#include <QtWidgets/QGroupBox>
 
 
 class Window ;

--- a/src/mokaQtIhm/object-options/options-volumic-homology.qt.cc
+++ b/src/mokaQtIhm/object-options/options-volumic-homology.qt.cc
@@ -26,10 +26,10 @@
 #include "HtmlEntities.hh"
 #include "compute-homology.hh"
 
-#include <QtGui/QGridLayout>
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QLabel>
-#include <Qt3Support/Q3Accel>
+#include <QtWidgets/QGridLayout>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QLabel>
+//#include <Qt3Support/Q3Accel>
 
 #ifndef _WINDOWS
 #include "chrono.hh"
@@ -48,9 +48,9 @@ OptionsVolumicHomology :: OptionsVolumicHomology(Window * parent) :
 
    // Definition du raccourci
 
-   Q3Accel * Raccourci = new Q3Accel(this) ;
-   Raccourci -> insertItem(QKeySequence(Qt :: Key_Space) , 9) ;
-   Raccourci -> connectItem(9 , this , SLOT(close()))  ;
+//   Q3Accel * Raccourci = new Q3Accel(this) ;
+//   Raccourci -> insertItem(QKeySequence(Qt :: Key_Space) , 9) ;
+//   Raccourci -> connectItem(9 , this , SLOT(close()))  ;
 
    QVBoxLayout * placement = new QVBoxLayout(this) ;
 

--- a/src/mokaQtIhm/object-options/options-volumic-homology.qt.cc
+++ b/src/mokaQtIhm/object-options/options-volumic-homology.qt.cc
@@ -29,7 +29,7 @@
 #include <QtWidgets/QGridLayout>
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QLabel>
-//#include <Qt3Support/Q3Accel>
+#include <QtWidgets/QShortcut>
 
 #ifndef _WINDOWS
 #include "chrono.hh"
@@ -47,10 +47,7 @@ OptionsVolumicHomology :: OptionsVolumicHomology(Window * parent) :
    setWindowTitle("Homology") ;
 
    // Definition du raccourci
-
-//   Q3Accel * Raccourci = new Q3Accel(this) ;
-//   Raccourci -> insertItem(QKeySequence(Qt :: Key_Space) , 9) ;
-//   Raccourci -> connectItem(9 , this , SLOT(close()))  ;
+   new QShortcut(QKeySequence ( Qt::Key_Space ), this, SLOT(close()));
 
    QVBoxLayout * placement = new QVBoxLayout(this) ;
 

--- a/src/mokaQtIhm/object-options/options-volumic-homology.qt.hh
+++ b/src/mokaQtIhm/object-options/options-volumic-homology.qt.hh
@@ -34,9 +34,9 @@
 //--------------------- Include QT --------------------
 
 #include <QtOpenGL/QGLWidget>
-#include <QtGui/QLabel>
-#include <QtGui/QDialog>
-#include <QtGui/QGroupBox>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QDialog>
+#include <QtWidgets/QGroupBox>
 
 
 class Window ;

--- a/src/mokaQtIhm/object-options/options-vue.qt.cc
+++ b/src/mokaQtIhm/object-options/options-vue.qt.cc
@@ -26,10 +26,10 @@
 #include "options-frame.qt.hh"
 #include "HtmlEntities.hh"
 
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QGridLayout>
-#include <QtGui/QLabel>
-#include <QtGui/QVBoxLayout>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QGridLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QVBoxLayout>
 
 #define SCALE_MAX (1.0)
 

--- a/src/mokaQtIhm/object-options/options-vue.qt.hh
+++ b/src/mokaQtIhm/object-options/options-vue.qt.hh
@@ -28,13 +28,13 @@
 #include "controler-gmap.hh"
 #include "IdWidgets.qt.hh"
 
-#include <QtGui/QSpinBox>
-#include <QtGui/QCheckBox>
-#include <QtGui/QComboBox>
-#include <QtGui/QSlider>
-#include <QtGui/QLabel>
-#include <QtGui/QPushButton>
-#include <QtGui/QGroupBox>
+#include <QtWidgets/QSpinBox>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QSlider>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QGroupBox>
 
 class Window ;
 

--- a/src/mokaQtIhm/utils/IdWidgets.qt.hh
+++ b/src/mokaQtIhm/utils/IdWidgets.qt.hh
@@ -24,10 +24,10 @@
 #ifndef _IDWIDGETS_H
 #define _IDWIDGETS_H
 
-#include <QtGui/QPushButton>
-#include <QtGui/QRadioButton>
-#include <QtGui/QAction>
-#include <QtGui/QWidget>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QRadioButton>
+#include <QtWidgets/QAction>
+#include <QtWidgets/QWidget>
 
 
 // Des QPushButton avec un identifiant.

--- a/src/mokaQtIhm/utils/SpaceWidget.qt.hh
+++ b/src/mokaQtIhm/utils/SpaceWidget.qt.hh
@@ -24,8 +24,8 @@
 #ifndef _SPACEWIDGET_H
 #define _SPACEWIDGET_H
 
-#include <QtGui/QBoxLayout>
-#include <QtGui/QWidget>
+#include <QtWidgets/QBoxLayout>
+#include <QtWidgets/QWidget>
 
 
 class SpaceWidget : public QWidget

--- a/src/mokaQtIhm/utils/floatSpinBox.qt.hh
+++ b/src/mokaQtIhm/utils/floatSpinBox.qt.hh
@@ -32,9 +32,9 @@ using namespace std ;
 #include <string.h>
 
 //------------- Include QT --------------
-#include <QtGui/QSpinBox>
+#include <QtWidgets/QSpinBox>
 #include <QtGui/QValidator> 
-#include <QtGui/QLineEdit> 
+#include <QtWidgets/QLineEdit>
 #include <QtCore/QString>
 
 class FloatSpinBox : public QDoubleSpinBox

--- a/src/mokaQtIhm/windows/dialog-do.qt.cc
+++ b/src/mokaQtIhm/windows/dialog-do.qt.cc
@@ -24,9 +24,9 @@
 #include "dialog-do.qt.hh"
 #include "window.qt.hh"
 
-#include <QtGui/QVBoxLayout>
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QLabel>
+#include <QtWidgets/QVBoxLayout>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QLabel>
 
 //**********************************************
 // Constructeur

--- a/src/mokaQtIhm/windows/dialog-do.qt.hh
+++ b/src/mokaQtIhm/windows/dialog-do.qt.hh
@@ -29,11 +29,11 @@
 using namespace GMap3d ;
 
 //------------------ Include QT -------------------
-#include <QtGui/QLabel>
-#include <QtGui/QSpinBox>
-#include <QtGui/QCheckBox>
-#include <QtGui/QPushButton>
-#include <QtGui/QDialog>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QSpinBox>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QDialog>
 
 
 class Window ;

--- a/src/mokaQtIhm/windows/gl-multi-window.qt.cc
+++ b/src/mokaQtIhm/windows/gl-multi-window.qt.cc
@@ -45,7 +45,7 @@ using namespace GMap3d ;
 // Constructeur
 //*******************************************************
 
-GLMultiWindow :: GLMultiWindow ( QWorkspace * parent , Window * owner ,
+GLMultiWindow :: GLMultiWindow ( QMdiArea * parent , Window * owner ,
 				 GLWindow * share , SelectBar * selection ) :
   GLWindow       ( VIEW_ISO , parent , owner , share , selection ),
   FCliqued       (0),
@@ -53,7 +53,7 @@ GLMultiWindow :: GLMultiWindow ( QWorkspace * parent , Window * owner ,
 {
   string str = getViewTypeString();
   setWindowTitle(*HTML::decode(&str));
-  parent->addWindow(this);
+  parent->addSubWindow(this);
 }
 
 

--- a/src/mokaQtIhm/windows/gl-multi-window.qt.hh
+++ b/src/mokaQtIhm/windows/gl-multi-window.qt.hh
@@ -54,7 +54,7 @@ public:
    * @param owner Fenetre principale
    * @param share Vue avec laquelle est partage le contexte OpenGL
    */
-  GLMultiWindow ( QWorkspace * parent , Window * owner , GLWindow * share ,
+  GLMultiWindow ( QMdiArea * parent , Window * owner , GLWindow * share ,
 		  SelectBar * selection ) ;
   
   /**

--- a/src/mokaQtIhm/windows/gl-window.qt.cc
+++ b/src/mokaQtIhm/windows/gl-window.qt.cc
@@ -127,7 +127,7 @@ void GLWindow::closeEvent(QCloseEvent * e)
 //************************************************************
 void GLWindow::paintGL()
 {
-  QPainter p(this);
+//  QPainter p(this);
 
   makeCurrent();
   glPushAttrib(GL_ALL_ATTRIB_BITS);
@@ -154,16 +154,16 @@ void GLWindow::paintGL()
   glPopMatrix();
   glPopAttrib();
 
-  if (FDragMode)
-    {
-      p.setPen(Qt::white) ;
-      p.drawRect(FStartX, FStartY, FCurX - FStartX, FCurY - FStartY);
-      if ( FOwner->getControler()->getModeDeselectionAtStop() )
-	p.drawText(FStartX, FStartY, "Deselect");
-      else
-	p.drawText(FStartX, FStartY, "Select");
-    }
-  p.end();
+//  if (FDragMode)
+//    {
+//      p.setPen(Qt::white) ;
+//      p.drawRect(FStartX, FStartY, FCurX - FStartX, FCurY - FStartY);
+//      if ( FOwner->getControler()->getModeDeselectionAtStop() )
+//	p.drawText(FStartX, FStartY, "Deselect");
+//      else
+//	p.drawText(FStartX, FStartY, "Select");
+//    }
+//  p.end();
 }
 //************************************************************
 // Modif de la taille de la fenetre

--- a/src/mokaQtIhm/windows/gl-window.qt.cc
+++ b/src/mokaQtIhm/windows/gl-window.qt.cc
@@ -34,7 +34,7 @@ using namespace GMap3d ;
 //*****************************************************
 // Constructeurs
 //*****************************************************
-GLWindow :: GLWindow(TView AViewType , QWorkspace * parent ,
+GLWindow :: GLWindow(TView AViewType , QMdiArea * parent ,
                      Window * owner , SelectBar * selection) :
       QGLWidget(QGLFormat(QGL::SampleBuffers), parent , 0, Qt::SubWindow),
       FViewType(AViewType),
@@ -46,11 +46,11 @@ GLWindow :: GLWindow(TView AViewType , QWorkspace * parent ,
 {
    string str = getViewTypeString();
    setWindowTitle(*HTML::decode(&str));
-   parent->addWindow(this);
+   parent->addSubWindow(this);
    setAcceptDrops(true);
 }
 
-GLWindow :: GLWindow(TView AViewType , QWorkspace * parent ,
+GLWindow :: GLWindow(TView AViewType , QMdiArea * parent ,
                      Window * owner , GLWindow * share ,
                      SelectBar * selection) :
       QGLWidget(parent, share , Qt::SubWindow) ,
@@ -63,7 +63,7 @@ GLWindow :: GLWindow(TView AViewType , QWorkspace * parent ,
 {
    string str = getViewTypeString();
    setWindowTitle(*HTML::decode(&str));
-   parent->addWindow(this);
+   parent->addSubWindow(this);
    setAcceptDrops(true);
 }
 //******************************************************

--- a/src/mokaQtIhm/windows/gl-window.qt.cc
+++ b/src/mokaQtIhm/windows/gl-window.qt.cc
@@ -127,7 +127,9 @@ void GLWindow::closeEvent(QCloseEvent * e)
 //************************************************************
 void GLWindow::paintGL()
 {
-//  QPainter p(this);
+#ifndef DISABLE_SELECTION_BOX
+  QPainter p(this);
+#endif
 
   makeCurrent();
   glPushAttrib(GL_ALL_ATTRIB_BITS);
@@ -154,16 +156,18 @@ void GLWindow::paintGL()
   glPopMatrix();
   glPopAttrib();
 
-//  if (FDragMode)
-//    {
-//      p.setPen(Qt::white) ;
-//      p.drawRect(FStartX, FStartY, FCurX - FStartX, FCurY - FStartY);
-//      if ( FOwner->getControler()->getModeDeselectionAtStop() )
-//	p.drawText(FStartX, FStartY, "Deselect");
-//      else
-//	p.drawText(FStartX, FStartY, "Select");
-//    }
-//  p.end();
+#ifndef DISABLE_SELECTION_BOX
+  if (FDragMode)
+    {
+      p.setPen(Qt::white) ;
+      p.drawRect(FStartX, FStartY, FCurX - FStartX, FCurY - FStartY);
+      if ( FOwner->getControler()->getModeDeselectionAtStop() )
+        p.drawText(FStartX, FStartY, "Deselect");
+      else
+        p.drawText(FStartX, FStartY, "Select");
+    }
+  p.end();
+#endif
 }
 //************************************************************
 // Modif de la taille de la fenetre

--- a/src/mokaQtIhm/windows/gl-window.qt.hh
+++ b/src/mokaQtIhm/windows/gl-window.qt.hh
@@ -35,7 +35,7 @@
 #include "controler-gmap.hh"
 
 //------------------ Include QT -------------------
-#include <QtGui/QWorkspace>
+#include <QtWidgets/QMdiArea>
 
 class Window ;
 
@@ -52,7 +52,7 @@ public:
    * @param owner Fenetre mere
    * @param selection Pointeur sur la barre de selection
    */
-  GLWindow ( TView AViewType , QWorkspace * parent , Window * owner ,
+  GLWindow ( TView AViewType , QMdiArea * parent , Window * owner ,
 	     SelectBar * selection ) ;
 
   /**
@@ -63,7 +63,7 @@ public:
    * @param share Vue avec laquelle elle partage le contexte OpenGL
    * @param selection Pointeur sur la barre de selection
    */
-  GLWindow ( TView AViewType , QWorkspace * parent , 
+  GLWindow ( TView AViewType , QMdiArea * parent ,
 	     Window * owner , GLWindow * share , SelectBar * selection  ) ;
   
   /**

--- a/src/mokaQtIhm/windows/menu-bar.qt.hh
+++ b/src/mokaQtIhm/windows/menu-bar.qt.hh
@@ -29,9 +29,9 @@ class Window ;
 
 //------------------ Include QT -------------------
 
-#include <QtGui/QMenuBar>
-#include <QtGui/QMenu>
-#include <QtGui/QAction>
+#include <QtWidgets/QMenuBar>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QAction>
 
 
 

--- a/src/mokaQtIhm/windows/select-bar.qt.cc
+++ b/src/mokaQtIhm/windows/select-bar.qt.cc
@@ -25,8 +25,8 @@
 #include "window.qt.hh"
 #include "HtmlEntities.hh"
 
-#include <QtGui/QVBoxLayout>
-#include <QtGui/QToolTip>
+#include <QtWidgets/QVBoxLayout>
+#include <QtWidgets/QToolTip>
 
 #define NB_SELECTION_BOUTONS 16
 

--- a/src/mokaQtIhm/windows/select-bar.qt.hh
+++ b/src/mokaQtIhm/windows/select-bar.qt.hh
@@ -32,9 +32,9 @@ using namespace GMap3d ;
 class Window ;
 
 //------------------ Include QT -------------------
-#include <QtGui/QPushButton>
-#include <QtGui/QToolBar>
-#include <QtGui/QGroupBox>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QToolBar>
+#include <QtWidgets/QGroupBox>
 #include "IdWidgets.qt.hh"
 
 class SelectBar : public QToolBar

--- a/src/mokaQtIhm/windows/window.qt.cc
+++ b/src/mokaQtIhm/windows/window.qt.cc
@@ -31,11 +31,11 @@
 #include <string>
 
 #include <QtGui/QPixmap>
-#include <QtGui/QToolButton>
-#include <QtGui/QMessageBox>
-#include <QtGui/QStatusBar>
-#include <QtGui/QFileDialog>
-#include <Qt3Support/Q3Accel>
+#include <QtWidgets/QToolButton>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QStatusBar>
+#include <QtWidgets/QFileDialog>
+//#include <Qt3Support/Q3Accel>
 
 
 //***************************************
@@ -72,7 +72,7 @@ Window :: Window() :
    setMenuBar(main_menu);
 
    // Creation du workspace
-   FWorkspace = new QWorkspace(this) ;
+   FWorkspace = new QMdiArea(this) ;
    setCentralWidget(FWorkspace) ;
    connect(FWorkspace, SIGNAL(windowActivated(QWidget *)),
            this, SLOT(windowActivated(QWidget *)));
@@ -91,83 +91,83 @@ Window :: Window() :
    FVueMere -> showMaximized() ;
 
    // Création des racourcis clavier : todo passer tout en QT4
-   Q3Accel* Raccourci = new Q3Accel(this) ;
+//   Q3Accel* Raccourci = new Q3Accel(this) ;
 
-   Raccourci -> insertItem(QKeySequence("Alt+F9") , 8) ;
-   Raccourci -> connectItem(8 , this ,
-                            SLOT(callbackToggleNormal())) ;
+//   Raccourci -> insertItem(QKeySequence("Alt+F9") , 8) ;
+//   Raccourci -> connectItem(8 , this ,
+//                            SLOT(callbackToggleNormal())) ;
 
-   Raccourci -> insertItem(QKeySequence(Qt::Key_F9) , 9) ;
-   Raccourci -> connectItem(9 , this ,
-                            SLOT(callbackToggleSews())) ;
+//   Raccourci -> insertItem(QKeySequence(Qt::Key_F9) , 9) ;
+//   Raccourci -> connectItem(9 , this ,
+//                            SLOT(callbackToggleSews())) ;
 
-   Raccourci -> insertItem(QKeySequence(Qt::Key_F10) , 10) ;
-   Raccourci -> connectItem(10 , this ,
-                            SLOT(callbackToggleVertices())) ;
+//   Raccourci -> insertItem(QKeySequence(Qt::Key_F10) , 10) ;
+//   Raccourci -> connectItem(10 , this ,
+//                            SLOT(callbackToggleVertices())) ;
 
-   Raccourci -> insertItem(QKeySequence(Qt::Key_F11) , 11) ;
-   Raccourci -> connectItem(11 , this ,
-                            SLOT(callbackToggleFaces())) ;
+//   Raccourci -> insertItem(QKeySequence(Qt::Key_F11) , 11) ;
+//   Raccourci -> connectItem(11 , this ,
+//                            SLOT(callbackToggleFaces())) ;
 
-   Raccourci -> insertItem(QKeySequence(Qt::Key_F12) , 12) ;
-   Raccourci -> connectItem(12 , this ,
-                            SLOT(callbackToggleGrille())) ;
+//   Raccourci -> insertItem(QKeySequence(Qt::Key_F12) , 12) ;
+//   Raccourci -> connectItem(12 , this ,
+//                            SLOT(callbackToggleGrille())) ;
 
-   Raccourci -> insertItem(QKeySequence("Alt+F11") , 14) ;
-   Raccourci -> connectItem(14 , this ,
-                            SLOT(callbackTournerButton())) ;
+//   Raccourci -> insertItem(QKeySequence("Alt+F11") , 14) ;
+//   Raccourci -> connectItem(14 , this ,
+//                            SLOT(callbackTournerButton())) ;
 
-   Raccourci -> insertItem(QKeySequence(Qt::Key_Space) , 1) ;
-   Raccourci -> connectItem(1 , this ,
-                            SLOT(callbackHideAllWindow())) ;
+//   Raccourci -> insertItem(QKeySequence(Qt::Key_Space) , 1) ;
+//   Raccourci -> connectItem(1 , this ,
+//                            SLOT(callbackHideAllWindow())) ;
 
-   Raccourci -> insertItem(QKeySequence(Qt::Key_Up) , 15) ;
-   Raccourci -> connectItem(15, this, SLOT(callbackKeyUp()));
+//   Raccourci -> insertItem(QKeySequence(Qt::Key_Up) , 15) ;
+//   Raccourci -> connectItem(15, this, SLOT(callbackKeyUp()));
 
-   Raccourci -> insertItem(QKeySequence(Qt::Key_Down) , 16) ;
-   Raccourci -> connectItem(16, this, SLOT(callbackKeyDown()));
+//   Raccourci -> insertItem(QKeySequence(Qt::Key_Down) , 16) ;
+//   Raccourci -> connectItem(16, this, SLOT(callbackKeyDown()));
 
-   Raccourci -> insertItem(QKeySequence(Qt::Key_Left) , 17) ;
-   Raccourci -> connectItem(17, this, SLOT(callbackKeyLeft()));
+//   Raccourci -> insertItem(QKeySequence(Qt::Key_Left) , 17) ;
+//   Raccourci -> connectItem(17, this, SLOT(callbackKeyLeft()));
 
-   Raccourci -> insertItem(QKeySequence(Qt::Key_Right) , 18) ;
-   Raccourci -> connectItem(18, this, SLOT(callbackKeyRight()));
+//   Raccourci -> insertItem(QKeySequence(Qt::Key_Right) , 18) ;
+//   Raccourci -> connectItem(18, this, SLOT(callbackKeyRight()));
 
-   Raccourci -> insertItem(QKeySequence(Qt::CTRL + Qt::Key_Up) , 19) ;
-   Raccourci -> connectItem(19, this, SLOT(callbackKeyCtrlUp()));
+//   Raccourci -> insertItem(QKeySequence(Qt::CTRL + Qt::Key_Up) , 19) ;
+//   Raccourci -> connectItem(19, this, SLOT(callbackKeyCtrlUp()));
 
-   Raccourci -> insertItem(QKeySequence(Qt::CTRL + Qt::Key_Down) , 20) ;
-   Raccourci -> connectItem(20, this, SLOT(callbackKeyCtrlDown()));
+//   Raccourci -> insertItem(QKeySequence(Qt::CTRL + Qt::Key_Down) , 20) ;
+//   Raccourci -> connectItem(20, this, SLOT(callbackKeyCtrlDown()));
 
-   Raccourci -> insertItem(QKeySequence(Qt::CTRL + Qt::Key_Left) , 21) ;
-   Raccourci -> connectItem(21, this, SLOT(callbackKeyCtrlLeft()));
+//   Raccourci -> insertItem(QKeySequence(Qt::CTRL + Qt::Key_Left) , 21) ;
+//   Raccourci -> connectItem(21, this, SLOT(callbackKeyCtrlLeft()));
 
-   Raccourci -> insertItem(QKeySequence(Qt::CTRL + Qt::Key_Right) , 22) ;
-   Raccourci -> connectItem(22, this, SLOT(callbackKeyCtrlRight()));
+//   Raccourci -> insertItem(QKeySequence(Qt::CTRL + Qt::Key_Right) , 22) ;
+//   Raccourci -> connectItem(22, this, SLOT(callbackKeyCtrlRight()));
 
-   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_Up) , 23) ;
-   Raccourci -> connectItem(23, this, SLOT(callbackKeyShiftUp()));
+//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_Up) , 23) ;
+//   Raccourci -> connectItem(23, this, SLOT(callbackKeyShiftUp()));
 
-   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_Down) , 24) ;
-   Raccourci -> connectItem(24, this, SLOT(callbackKeyShiftDown()));
+//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_Down) , 24) ;
+//   Raccourci -> connectItem(24, this, SLOT(callbackKeyShiftDown()));
 
-   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_Left) , 25) ;
-   Raccourci -> connectItem(25, this, SLOT(callbackKeyShiftLeft()));
+//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_Left) , 25) ;
+//   Raccourci -> connectItem(25, this, SLOT(callbackKeyShiftLeft()));
 
-   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_Right) , 26);
-   Raccourci -> connectItem(26, this, SLOT(callbackKeyShiftRight()));
+//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_Right) , 26);
+//   Raccourci -> connectItem(26, this, SLOT(callbackKeyShiftRight()));
 
-   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_F8) , 27) ;
-   Raccourci -> connectItem(27 , this , SLOT(callbackVueCompacte())) ;
+//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_F8) , 27) ;
+//   Raccourci -> connectItem(27 , this , SLOT(callbackVueCompacte())) ;
 
-   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_F9) , 28) ;
-   Raccourci -> connectItem(28 , this , SLOT(callbackVueSemiEclatee()));
+//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_F9) , 28) ;
+//   Raccourci -> connectItem(28 , this , SLOT(callbackVueSemiEclatee()));
 
-   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_F10) , 29) ;
-   Raccourci -> connectItem(29 , this , SLOT(callbackVueMoka())) ;
+//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_F10) , 29) ;
+//   Raccourci -> connectItem(29 , this , SLOT(callbackVueMoka())) ;
 
-   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_F11) , 30) ;
-   Raccourci -> connectItem(30 , this , SLOT(callbackVueTopoFil())) ;
+//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_F11) , 30) ;
+//   Raccourci -> connectItem(30 , this , SLOT(callbackVueTopoFil())) ;
 
    // Creation des Toolbars
    FCreationBrin      = new CreationBrin(this , FControler);
@@ -246,7 +246,7 @@ void Window::repaint()
       QMainWindow::repaint() ;      // Appel de la methode de la classe mere
 
       // Appel de la methode sur toutes les vues ouvertes
-      QWidgetList vues = FWorkspace -> windowList() ;
+      QList<QMdiSubWindow*> vues = FWorkspace -> subWindowList() ;
       for (int i = 0 ; i < int (vues . count()) ; i++)
 	((GLWindow *) vues.at(i))->updateGL(); //paintGL(); //update(); //repaint() ;
 
@@ -341,18 +341,18 @@ OptionsVolumicHomology * Window::getOptionsVolumicHomologyActive() const
 //*****************************************
 void Window :: bascule(TView type)
 {
-   assert(FWorkspace->activeWindow() != NULL);
+   assert(FWorkspace->activeSubWindow() != NULL);
 
    bool find = false;
    int  actu = 0;
    int  first;
 
    // On cherche tout d'abord la vue active.
-   QWidgetList vues = FWorkspace -> windowList() ;
+   QList<QMdiSubWindow*> vues = FWorkspace -> subWindowList() ;
 
    while (!find && actu < int(vues.count()))
    {
-      if ((GLWindow*)FWorkspace->activeWindow() == (GLWindow*)vues.at(actu))
+      if ((GLWindow*)FWorkspace->activeSubWindow() == (GLWindow*)vues.at(actu))
          find = true;
       else
          ++actu;
@@ -380,7 +380,7 @@ void Window :: bascule(TView type)
    }
    else
    {
-      if (((GLWindow*)FWorkspace->activeWindow())->getViewType() != type)
+      if (((GLWindow*)FWorkspace->activeSubWindow())->getViewType() != type)
       {
          // Soit on cree une vue avec le bon type.
          switch (type)
@@ -517,10 +517,9 @@ std::string Window::getOpenFileName(const QString & caption,
                                     int * ind_filter)
 {
    QString filename;
-   QFileDialog open_dialog(0, caption, current_dir.path());
+   QFileDialog open_dialog(0, caption, current_dir.path(), filters.join(";;"));
 
    if (ind_filter != NULL) *ind_filter = -1;
-   open_dialog.setFilters(filters);
    open_dialog.setAcceptMode(QFileDialog::AcceptOpen);
    open_dialog.setFileMode(QFileDialog::ExistingFile);
 
@@ -532,7 +531,7 @@ std::string Window::getOpenFileName(const QString & caption,
       if (ind_filter != NULL)
       {
          for ((*ind_filter) = 0;
-               filters.at(*ind_filter) != open_dialog.selectedFilter();
+               filters.at(*ind_filter) != open_dialog.selectedNameFilter();
                (*ind_filter)++);
       }
       return filename.toStdString();
@@ -561,13 +560,12 @@ std::string Window::getSaveFileName(const QString & caption,
    assert(FileDialog == NULL);
 
    QString filename;
-   FileDialog = new QFileDialog(0, caption, current_dir.path());
+   FileDialog = new QFileDialog(0, caption, current_dir.path(), filters.join(";;"));
 
    connect(FileDialog, SIGNAL(filterSelected(const QString &)),
            this, SLOT(filterSelected(const QString &)));
 
    if (ind_filter != NULL) *ind_filter = -1;
-   FileDialog->setFilters(filters);
    FileDialog->setAcceptMode(QFileDialog::AcceptSave);
    FileDialog->setFileMode(QFileDialog::AnyFile);
    filterSelected(filters.at(0));
@@ -580,7 +578,7 @@ std::string Window::getSaveFileName(const QString & caption,
       if (ind_filter != NULL)
       {
          for ((*ind_filter) = 0;
-               filters.at(*ind_filter) != FileDialog->selectedFilter();
+               filters.at(*ind_filter) != FileDialog->selectedNameFilter();
                (*ind_filter)++);
       }
 
@@ -772,9 +770,9 @@ void Window :: setAxisDisplay(bool b)
 
 TViewId Window :: getCurrentViewId() const
 {
-   assert(FWorkspace->activeWindow() != NULL);
+   assert(FWorkspace->activeSubWindow() != NULL);
 
-   return ((GLWindow *) FWorkspace -> activeWindow())
+   return ((GLWindow *) FWorkspace -> activeSubWindow())
           -> getCliquedViewId() ;
 }
 
@@ -805,7 +803,7 @@ void Window :: callbackKeyUp()
 {
    int view = getCurrentViewId();
 
-   switch (((GLWindow *) FWorkspace -> activeWindow()) -> getViewType())
+   switch (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType())
    {
       case VIEW_XYZ :
       {
@@ -823,7 +821,7 @@ void Window :: callbackKeyDown()
 {
    int view = getCurrentViewId();
 
-   switch (((GLWindow *) FWorkspace -> activeWindow()) -> getViewType())
+   switch (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType())
    {
       case VIEW_XYZ :
       {
@@ -841,7 +839,7 @@ void Window :: callbackKeyLeft()
 {
    int view = getCurrentViewId();
 
-   switch (((GLWindow *) FWorkspace -> activeWindow()) -> getViewType())
+   switch (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType())
    {
       case VIEW_XYZ :
       {
@@ -859,7 +857,7 @@ void Window :: callbackKeyRight()
 {
    int view = getCurrentViewId();
 
-   switch (((GLWindow *) FWorkspace -> activeWindow()) -> getViewType())
+   switch (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType())
    {
       case VIEW_XYZ :
       {
@@ -875,7 +873,7 @@ void Window :: callbackKeyRight()
 
 void Window :: callbackKeyCtrlUp()
 {
-   if (((GLWindow *) FWorkspace -> activeWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
    {
       FControler -> verticalRotationEye(getCurrentViewId(), true);
       repaint();
@@ -884,7 +882,7 @@ void Window :: callbackKeyCtrlUp()
 
 void Window :: callbackKeyCtrlDown()
 {
-   if (((GLWindow *) FWorkspace -> activeWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
    {
       FControler -> verticalRotationEye(getCurrentViewId(), false);
       repaint();
@@ -893,7 +891,7 @@ void Window :: callbackKeyCtrlDown()
 
 void Window :: callbackKeyCtrlLeft()
 {
-   if (((GLWindow *) FWorkspace -> activeWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
    {
       FControler -> moveEyeLateral(getCurrentViewId(), false);
       repaint();
@@ -902,7 +900,7 @@ void Window :: callbackKeyCtrlLeft()
 
 void Window :: callbackKeyCtrlRight()
 {
-   if (((GLWindow *) FWorkspace -> activeWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
    {
       FControler -> moveEyeLateral(getCurrentViewId(), true);
       repaint();
@@ -911,7 +909,7 @@ void Window :: callbackKeyCtrlRight()
 
 void Window :: callbackKeyShiftUp()
 {
-   if (((GLWindow *) FWorkspace -> activeWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
    {
       TViewId AView = getCurrentViewId();
       float coeff =
@@ -923,7 +921,7 @@ void Window :: callbackKeyShiftUp()
 
 void Window :: callbackKeyShiftDown()
 {
-   if (((GLWindow *) FWorkspace -> activeWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
    {
       TViewId AView = getCurrentViewId();
       float coeff =
@@ -935,7 +933,7 @@ void Window :: callbackKeyShiftDown()
 
 void Window :: callbackKeyShiftLeft()
 {
-   if (((GLWindow *) FWorkspace -> activeWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
    {
       FControler -> horizontalRotationEye(getCurrentViewId(), true, 90);
       repaint();
@@ -944,7 +942,7 @@ void Window :: callbackKeyShiftLeft()
 
 void Window :: callbackKeyShiftRight()
 {
-   if (((GLWindow *) FWorkspace -> activeWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
    {
       FControler -> horizontalRotationEye(getCurrentViewId(), false, 90);
       repaint();
@@ -2955,12 +2953,12 @@ void Window :: callbackGoAlpha3()
 //***************************************
 void Window :: tile()
 {
-   FWorkspace -> tile() ;
+   FWorkspace -> tileSubWindows(); ;
 }
 
 void Window :: cascade()
 {
-   FWorkspace -> cascade() ;
+   FWorkspace -> cascadeSubWindows();
 }
 
 void Window :: addView3D()
@@ -3030,7 +3028,7 @@ void Window :: basculeViewMulti()
 
 void Window :: deleteView()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    active -> closeEvent(NULL) ;
 }
 
@@ -3066,21 +3064,21 @@ void Window :: OperationUngroupAllDrawing()
 
 void Window :: OperationUngroupGeneral()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    FControler -> viewUngroup(active -> getCliquedViewId()) ;
    repaint() ;
 }
 
 void Window :: OperationUngroupPrecompiles()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    FControler -> viewUngroupPrecompiles(active -> getCliquedViewId()) ;
    repaint() ;
 }
 
 void Window :: OperationUngroupEyePos()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    FControler -> viewUngroupParameter(active -> getCliquedViewId() ,
                                       PARAMETER_EYE_POSITION) ;
    repaint() ;
@@ -3088,7 +3086,7 @@ void Window :: OperationUngroupEyePos()
 
 void Window :: OperationUngroupAimedPos()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    FControler -> viewUngroupParameter(active -> getCliquedViewId() ,
                                       PARAMETER_AIMED_POSITION) ;
    repaint() ;
@@ -3096,7 +3094,7 @@ void Window :: OperationUngroupAimedPos()
 
 void Window :: OperationUngroupDrawing()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    FControler -> viewUngroupParameter(active -> getCliquedViewId() ,
                                       PARAMETER_DRAWING) ;
    repaint() ;
@@ -3104,21 +3102,21 @@ void Window :: OperationUngroupDrawing()
 
 void Window :: OperationGroupAllGeneral()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    FControler -> viewGroupAll(active -> getCliquedViewId()) ;
    repaint() ;
 }
 
 void Window :: OperationGroupAllPrecomp()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    FControler -> viewGroupAllPrecompiles(active -> getCliquedViewId()) ;
    repaint() ;
 }
 
 void Window :: OperationGroupAllEyePos()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    FControler -> viewGroupAllParameter(active -> getCliquedViewId() ,
                                        PARAMETER_EYE_POSITION) ;
    repaint() ;
@@ -3126,7 +3124,7 @@ void Window :: OperationGroupAllEyePos()
 
 void Window :: OperationGroupAllAimedPos()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    FControler -> viewGroupAllParameter(active -> getCliquedViewId() ,
                                        PARAMETER_AIMED_POSITION) ;
    repaint() ;
@@ -3134,7 +3132,7 @@ void Window :: OperationGroupAllAimedPos()
 
 void Window :: OperationGroupAllDrawing()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    FControler -> viewGroupAllParameter(active -> getCliquedViewId() ,
                                        PARAMETER_DRAWING) ;
    repaint() ;
@@ -3142,7 +3140,7 @@ void Window :: OperationGroupAllDrawing()
 
 void Window :: OperationGroupGeneral()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    FControler -> viewGroup(active -> getCliquedViewId(),
                            FDoubleCliquee -> getDoubleCliquedViewId());
    repaint() ;
@@ -3150,7 +3148,7 @@ void Window :: OperationGroupGeneral()
 
 void Window :: OperationGroupPrecomp()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    FControler->viewGroupPrecompiles(active -> getCliquedViewId(),
                                     FDoubleCliquee->getDoubleCliquedViewId());
    repaint() ;
@@ -3158,7 +3156,7 @@ void Window :: OperationGroupPrecomp()
 
 void Window :: OperationGroupEyePos()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    FControler -> viewGroupParameter(active -> getCliquedViewId() ,
                                     FDoubleCliquee -> getDoubleCliquedViewId(),
                                     PARAMETER_EYE_POSITION) ;
@@ -3167,7 +3165,7 @@ void Window :: OperationGroupEyePos()
 
 void Window :: OperationGroupAimedPos()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    FControler -> viewGroupParameter(active -> getCliquedViewId() ,
                                     FDoubleCliquee -> getDoubleCliquedViewId(),
                                     PARAMETER_AIMED_POSITION) ;
@@ -3176,7 +3174,7 @@ void Window :: OperationGroupAimedPos()
 
 void Window :: OperationGroupDrawing()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
    FControler -> viewGroupParameter(active -> getCliquedViewId() ,
                                     FDoubleCliquee -> getDoubleCliquedViewId(),
                                     PARAMETER_DRAWING) ;

--- a/src/mokaQtIhm/windows/window.qt.cc
+++ b/src/mokaQtIhm/windows/window.qt.cc
@@ -35,6 +35,8 @@
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QStatusBar>
 #include <QtWidgets/QFileDialog>
+#include <QtWidgets/QMdiArea>
+#include <QtWidgets/QMdiSubWindow>
 //#include <Qt3Support/Q3Accel>
 
 
@@ -74,8 +76,8 @@ Window :: Window() :
    // Creation du workspace
    FWorkspace = new QMdiArea(this) ;
    setCentralWidget(FWorkspace) ;
-   connect(FWorkspace, SIGNAL(windowActivated(QWidget *)),
-           this, SLOT(windowActivated(QWidget *)));
+   connect(FWorkspace, SIGNAL(subWindowActivated(QMdiSubWindow *)),
+           this, SLOT(subWindowActivated(QMdiSubWindow *)));
 
    // Affectation du mode du controleur
    FControler -> setMode(MODE_SELECTION) ;
@@ -248,7 +250,7 @@ void Window::repaint()
       // Appel de la methode sur toutes les vues ouvertes
       QList<QMdiSubWindow*> vues = FWorkspace -> subWindowList() ;
       for (int i = 0 ; i < int (vues . count()) ; i++)
-	((GLWindow *) vues.at(i))->updateGL(); //paintGL(); //update(); //repaint() ;
+        ((GLWindow *) vues.at(i)->widget())->updateGL(); //paintGL(); //update(); //repaint() ;
 
       updateStatusBar();
       is_repainting = false;
@@ -260,7 +262,7 @@ void Window::closeEvent(QCloseEvent *)
    FControler -> saveAllParameters(getCurrentViewId());
 }
 
-void Window::windowActivated(QWidget * w)
+void Window::subWindowActivated(QMdiSubWindow * w)
 {
    if (w == NULL) return;
 
@@ -341,7 +343,7 @@ OptionsVolumicHomology * Window::getOptionsVolumicHomologyActive() const
 //*****************************************
 void Window :: bascule(TView type)
 {
-   assert(FWorkspace->activeSubWindow() != NULL);
+   assert(FWorkspace->activeSubWindow()->widget() != NULL);
 
    bool find = false;
    int  actu = 0;
@@ -352,7 +354,7 @@ void Window :: bascule(TView type)
 
    while (!find && actu < int(vues.count()))
    {
-      if ((GLWindow*)FWorkspace->activeSubWindow() == (GLWindow*)vues.at(actu))
+      if ((GLWindow*)FWorkspace->activeSubWindow()->widget() == (GLWindow*)vues.at(actu)->widget())
          find = true;
       else
          ++actu;
@@ -380,7 +382,7 @@ void Window :: bascule(TView type)
    }
    else
    {
-      if (((GLWindow*)FWorkspace->activeSubWindow())->getViewType() != type)
+      if (((GLWindow*)FWorkspace->activeSubWindow()->widget())->getViewType() != type)
       {
          // Soit on cree une vue avec le bon type.
          switch (type)
@@ -770,9 +772,9 @@ void Window :: setAxisDisplay(bool b)
 
 TViewId Window :: getCurrentViewId() const
 {
-   assert(FWorkspace->activeSubWindow() != NULL);
+   assert(FWorkspace->activeSubWindow()->widget() != NULL);
 
-   return ((GLWindow *) FWorkspace -> activeSubWindow())
+   return ((GLWindow *) FWorkspace -> activeSubWindow()->widget())
           -> getCliquedViewId() ;
 }
 
@@ -803,7 +805,7 @@ void Window :: callbackKeyUp()
 {
    int view = getCurrentViewId();
 
-   switch (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType())
+   switch (((GLWindow *) FWorkspace -> activeSubWindow()->widget()) -> getViewType())
    {
       case VIEW_XYZ :
       {
@@ -821,7 +823,7 @@ void Window :: callbackKeyDown()
 {
    int view = getCurrentViewId();
 
-   switch (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType())
+   switch (((GLWindow *) FWorkspace -> activeSubWindow()->widget()) -> getViewType())
    {
       case VIEW_XYZ :
       {
@@ -839,7 +841,7 @@ void Window :: callbackKeyLeft()
 {
    int view = getCurrentViewId();
 
-   switch (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType())
+   switch (((GLWindow *) FWorkspace -> activeSubWindow()->widget()) -> getViewType())
    {
       case VIEW_XYZ :
       {
@@ -857,7 +859,7 @@ void Window :: callbackKeyRight()
 {
    int view = getCurrentViewId();
 
-   switch (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType())
+   switch (((GLWindow *) FWorkspace -> activeSubWindow()->widget()) -> getViewType())
    {
       case VIEW_XYZ :
       {
@@ -873,7 +875,7 @@ void Window :: callbackKeyRight()
 
 void Window :: callbackKeyCtrlUp()
 {
-   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()->widget()) -> getViewType() == VIEW_XYZ)
    {
       FControler -> verticalRotationEye(getCurrentViewId(), true);
       repaint();
@@ -882,7 +884,7 @@ void Window :: callbackKeyCtrlUp()
 
 void Window :: callbackKeyCtrlDown()
 {
-   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()->widget()) -> getViewType() == VIEW_XYZ)
    {
       FControler -> verticalRotationEye(getCurrentViewId(), false);
       repaint();
@@ -891,7 +893,7 @@ void Window :: callbackKeyCtrlDown()
 
 void Window :: callbackKeyCtrlLeft()
 {
-   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()->widget()) -> getViewType() == VIEW_XYZ)
    {
       FControler -> moveEyeLateral(getCurrentViewId(), false);
       repaint();
@@ -900,7 +902,7 @@ void Window :: callbackKeyCtrlLeft()
 
 void Window :: callbackKeyCtrlRight()
 {
-   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()->widget()) -> getViewType() == VIEW_XYZ)
    {
       FControler -> moveEyeLateral(getCurrentViewId(), true);
       repaint();
@@ -909,7 +911,7 @@ void Window :: callbackKeyCtrlRight()
 
 void Window :: callbackKeyShiftUp()
 {
-   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()->widget()) -> getViewType() == VIEW_XYZ)
    {
       TViewId AView = getCurrentViewId();
       float coeff =
@@ -921,7 +923,7 @@ void Window :: callbackKeyShiftUp()
 
 void Window :: callbackKeyShiftDown()
 {
-   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()->widget()) -> getViewType() == VIEW_XYZ)
    {
       TViewId AView = getCurrentViewId();
       float coeff =
@@ -933,7 +935,7 @@ void Window :: callbackKeyShiftDown()
 
 void Window :: callbackKeyShiftLeft()
 {
-   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()->widget()) -> getViewType() == VIEW_XYZ)
    {
       FControler -> horizontalRotationEye(getCurrentViewId(), true, 90);
       repaint();
@@ -942,7 +944,7 @@ void Window :: callbackKeyShiftLeft()
 
 void Window :: callbackKeyShiftRight()
 {
-   if (((GLWindow *) FWorkspace -> activeSubWindow()) -> getViewType() == VIEW_XYZ)
+   if (((GLWindow *) FWorkspace -> activeSubWindow()->widget()) -> getViewType() == VIEW_XYZ)
    {
       FControler -> horizontalRotationEye(getCurrentViewId(), false, 90);
       repaint();
@@ -3028,7 +3030,7 @@ void Window :: basculeViewMulti()
 
 void Window :: deleteView()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    active -> closeEvent(NULL) ;
 }
 
@@ -3064,21 +3066,21 @@ void Window :: OperationUngroupAllDrawing()
 
 void Window :: OperationUngroupGeneral()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    FControler -> viewUngroup(active -> getCliquedViewId()) ;
    repaint() ;
 }
 
 void Window :: OperationUngroupPrecompiles()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    FControler -> viewUngroupPrecompiles(active -> getCliquedViewId()) ;
    repaint() ;
 }
 
 void Window :: OperationUngroupEyePos()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    FControler -> viewUngroupParameter(active -> getCliquedViewId() ,
                                       PARAMETER_EYE_POSITION) ;
    repaint() ;
@@ -3086,7 +3088,7 @@ void Window :: OperationUngroupEyePos()
 
 void Window :: OperationUngroupAimedPos()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    FControler -> viewUngroupParameter(active -> getCliquedViewId() ,
                                       PARAMETER_AIMED_POSITION) ;
    repaint() ;
@@ -3094,7 +3096,7 @@ void Window :: OperationUngroupAimedPos()
 
 void Window :: OperationUngroupDrawing()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    FControler -> viewUngroupParameter(active -> getCliquedViewId() ,
                                       PARAMETER_DRAWING) ;
    repaint() ;
@@ -3102,21 +3104,21 @@ void Window :: OperationUngroupDrawing()
 
 void Window :: OperationGroupAllGeneral()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    FControler -> viewGroupAll(active -> getCliquedViewId()) ;
    repaint() ;
 }
 
 void Window :: OperationGroupAllPrecomp()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    FControler -> viewGroupAllPrecompiles(active -> getCliquedViewId()) ;
    repaint() ;
 }
 
 void Window :: OperationGroupAllEyePos()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    FControler -> viewGroupAllParameter(active -> getCliquedViewId() ,
                                        PARAMETER_EYE_POSITION) ;
    repaint() ;
@@ -3124,7 +3126,7 @@ void Window :: OperationGroupAllEyePos()
 
 void Window :: OperationGroupAllAimedPos()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    FControler -> viewGroupAllParameter(active -> getCliquedViewId() ,
                                        PARAMETER_AIMED_POSITION) ;
    repaint() ;
@@ -3132,7 +3134,7 @@ void Window :: OperationGroupAllAimedPos()
 
 void Window :: OperationGroupAllDrawing()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    FControler -> viewGroupAllParameter(active -> getCliquedViewId() ,
                                        PARAMETER_DRAWING) ;
    repaint() ;
@@ -3140,7 +3142,7 @@ void Window :: OperationGroupAllDrawing()
 
 void Window :: OperationGroupGeneral()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    FControler -> viewGroup(active -> getCliquedViewId(),
                            FDoubleCliquee -> getDoubleCliquedViewId());
    repaint() ;
@@ -3148,7 +3150,7 @@ void Window :: OperationGroupGeneral()
 
 void Window :: OperationGroupPrecomp()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    FControler->viewGroupPrecompiles(active -> getCliquedViewId(),
                                     FDoubleCliquee->getDoubleCliquedViewId());
    repaint() ;
@@ -3156,7 +3158,7 @@ void Window :: OperationGroupPrecomp()
 
 void Window :: OperationGroupEyePos()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    FControler -> viewGroupParameter(active -> getCliquedViewId() ,
                                     FDoubleCliquee -> getDoubleCliquedViewId(),
                                     PARAMETER_EYE_POSITION) ;
@@ -3165,7 +3167,7 @@ void Window :: OperationGroupEyePos()
 
 void Window :: OperationGroupAimedPos()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    FControler -> viewGroupParameter(active -> getCliquedViewId() ,
                                     FDoubleCliquee -> getDoubleCliquedViewId(),
                                     PARAMETER_AIMED_POSITION) ;
@@ -3174,7 +3176,7 @@ void Window :: OperationGroupAimedPos()
 
 void Window :: OperationGroupDrawing()
 {
-   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()) ;
+   GLWindow * active = ((GLWindow *) FWorkspace -> activeSubWindow()->widget()) ;
    FControler -> viewGroupParameter(active -> getCliquedViewId() ,
                                     FDoubleCliquee -> getDoubleCliquedViewId(),
                                     PARAMETER_DRAWING) ;

--- a/src/mokaQtIhm/windows/window.qt.cc
+++ b/src/mokaQtIhm/windows/window.qt.cc
@@ -369,7 +369,7 @@ void Window :: bascule(TView type)
 
    while (!find && actu != first)
    {
-      if (((GLWindow*)vues.at(actu))->getViewType() == type)
+      if (((GLWindow*)vues.at(actu)->widget())->getViewType() == type)
          find = true;
       else
          actu = (actu + 1) % vues.count();
@@ -378,7 +378,7 @@ void Window :: bascule(TView type)
    if (find)
    {
       // Soit on active la vue
-      ((GLWindow*)vues.at(actu))->setFocus();
+      ((GLWindow*)vues.at(actu)->widget())->setFocus();
    }
    else
    {

--- a/src/mokaQtIhm/windows/window.qt.cc
+++ b/src/mokaQtIhm/windows/window.qt.cc
@@ -37,8 +37,7 @@
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QMdiArea>
 #include <QtWidgets/QMdiSubWindow>
-//#include <Qt3Support/Q3Accel>
-
+#include <QtWidgets/QShortcut>
 
 //***************************************
 // Constructeur
@@ -93,83 +92,29 @@ Window :: Window() :
    FVueMere -> showMaximized() ;
 
    // Création des racourcis clavier : todo passer tout en QT4
-//   Q3Accel* Raccourci = new Q3Accel(this) ;
-
-//   Raccourci -> insertItem(QKeySequence("Alt+F9") , 8) ;
-//   Raccourci -> connectItem(8 , this ,
-//                            SLOT(callbackToggleNormal())) ;
-
-//   Raccourci -> insertItem(QKeySequence(Qt::Key_F9) , 9) ;
-//   Raccourci -> connectItem(9 , this ,
-//                            SLOT(callbackToggleSews())) ;
-
-//   Raccourci -> insertItem(QKeySequence(Qt::Key_F10) , 10) ;
-//   Raccourci -> connectItem(10 , this ,
-//                            SLOT(callbackToggleVertices())) ;
-
-//   Raccourci -> insertItem(QKeySequence(Qt::Key_F11) , 11) ;
-//   Raccourci -> connectItem(11 , this ,
-//                            SLOT(callbackToggleFaces())) ;
-
-//   Raccourci -> insertItem(QKeySequence(Qt::Key_F12) , 12) ;
-//   Raccourci -> connectItem(12 , this ,
-//                            SLOT(callbackToggleGrille())) ;
-
-//   Raccourci -> insertItem(QKeySequence("Alt+F11") , 14) ;
-//   Raccourci -> connectItem(14 , this ,
-//                            SLOT(callbackTournerButton())) ;
-
-//   Raccourci -> insertItem(QKeySequence(Qt::Key_Space) , 1) ;
-//   Raccourci -> connectItem(1 , this ,
-//                            SLOT(callbackHideAllWindow())) ;
-
-//   Raccourci -> insertItem(QKeySequence(Qt::Key_Up) , 15) ;
-//   Raccourci -> connectItem(15, this, SLOT(callbackKeyUp()));
-
-//   Raccourci -> insertItem(QKeySequence(Qt::Key_Down) , 16) ;
-//   Raccourci -> connectItem(16, this, SLOT(callbackKeyDown()));
-
-//   Raccourci -> insertItem(QKeySequence(Qt::Key_Left) , 17) ;
-//   Raccourci -> connectItem(17, this, SLOT(callbackKeyLeft()));
-
-//   Raccourci -> insertItem(QKeySequence(Qt::Key_Right) , 18) ;
-//   Raccourci -> connectItem(18, this, SLOT(callbackKeyRight()));
-
-//   Raccourci -> insertItem(QKeySequence(Qt::CTRL + Qt::Key_Up) , 19) ;
-//   Raccourci -> connectItem(19, this, SLOT(callbackKeyCtrlUp()));
-
-//   Raccourci -> insertItem(QKeySequence(Qt::CTRL + Qt::Key_Down) , 20) ;
-//   Raccourci -> connectItem(20, this, SLOT(callbackKeyCtrlDown()));
-
-//   Raccourci -> insertItem(QKeySequence(Qt::CTRL + Qt::Key_Left) , 21) ;
-//   Raccourci -> connectItem(21, this, SLOT(callbackKeyCtrlLeft()));
-
-//   Raccourci -> insertItem(QKeySequence(Qt::CTRL + Qt::Key_Right) , 22) ;
-//   Raccourci -> connectItem(22, this, SLOT(callbackKeyCtrlRight()));
-
-//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_Up) , 23) ;
-//   Raccourci -> connectItem(23, this, SLOT(callbackKeyShiftUp()));
-
-//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_Down) , 24) ;
-//   Raccourci -> connectItem(24, this, SLOT(callbackKeyShiftDown()));
-
-//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_Left) , 25) ;
-//   Raccourci -> connectItem(25, this, SLOT(callbackKeyShiftLeft()));
-
-//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_Right) , 26);
-//   Raccourci -> connectItem(26, this, SLOT(callbackKeyShiftRight()));
-
-//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_F8) , 27) ;
-//   Raccourci -> connectItem(27 , this , SLOT(callbackVueCompacte())) ;
-
-//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_F9) , 28) ;
-//   Raccourci -> connectItem(28 , this , SLOT(callbackVueSemiEclatee()));
-
-//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_F10) , 29) ;
-//   Raccourci -> connectItem(29 , this , SLOT(callbackVueMoka())) ;
-
-//   Raccourci -> insertItem(QKeySequence(Qt::SHIFT + Qt::Key_F11) , 30) ;
-//   Raccourci -> connectItem(30 , this , SLOT(callbackVueTopoFil())) ;
+   new QShortcut(QKeySequence ( "Alt+F9" ), this, SLOT(callbackToggleNormal()));
+   new QShortcut(QKeySequence ( Qt::Key_F9 ), this, SLOT(callbackToggleSews()));
+   new QShortcut(QKeySequence ( Qt::Key_F10 ), this, SLOT(callbackToggleVertices()));
+   new QShortcut(QKeySequence ( Qt::Key_F11 ), this, SLOT(callbackToggleFaces()));
+   new QShortcut(QKeySequence ( Qt::Key_F12 ), this, SLOT(callbackToggleGrille()));
+   new QShortcut(QKeySequence ( "Alt+F11" ), this, SLOT(callbackTournerButton()));
+   new QShortcut(QKeySequence ( Qt::Key_Space ), this, SLOT(callbackHideAllWindow()));
+   new QShortcut(QKeySequence ( Qt::Key_Up ), this, SLOT(callbackKeyUp()));
+   new QShortcut(QKeySequence ( Qt::Key_Down ), this, SLOT(callbackKeyDown()));
+   new QShortcut(QKeySequence ( Qt::Key_Left ), this, SLOT(callbackKeyLeft()));
+   new QShortcut(QKeySequence ( Qt::Key_Right ), this, SLOT(callbackKeyRight()));
+   new QShortcut(QKeySequence ( Qt::CTRL + Qt::Key_Up ), this, SLOT(callbackKeyCtrlUp()));
+   new QShortcut(QKeySequence ( Qt::CTRL + Qt::Key_Down ), this, SLOT(callbackKeyCtrlDown()));
+   new QShortcut(QKeySequence ( Qt::CTRL + Qt::Key_Left ), this, SLOT(callbackKeyCtrlLeft()));
+   new QShortcut(QKeySequence ( Qt::CTRL + Qt::Key_Right ), this, SLOT(callbackKeyCtrlRight()));
+   new QShortcut(QKeySequence ( Qt::SHIFT + Qt::Key_Up ), this, SLOT(callbackKeyShiftUp()));
+   new QShortcut(QKeySequence ( Qt::SHIFT + Qt::Key_Down ), this, SLOT(callbackKeyShiftDown()));
+   new QShortcut(QKeySequence ( Qt::SHIFT + Qt::Key_Left ), this, SLOT(callbackKeyShiftLeft()));
+   new QShortcut(QKeySequence ( Qt::SHIFT + Qt::Key_Right ), this, SLOT(callbackKeyShiftRight()));
+   new QShortcut(QKeySequence ( Qt::SHIFT + Qt::Key_F8 ), this, SLOT(callbackVueCompacte()));
+   new QShortcut(QKeySequence ( Qt::SHIFT + Qt::Key_F9 ), this, SLOT(callbackVueSemiEclatee()));
+   new QShortcut(QKeySequence ( Qt::SHIFT + Qt::Key_F10 ), this, SLOT(callbackVueMoka()));
+   new QShortcut(QKeySequence ( Qt::SHIFT + Qt::Key_F11 ), this, SLOT(callbackVueTopoFil()));
 
    // Creation des Toolbars
    FCreationBrin      = new CreationBrin(this , FControler);

--- a/src/mokaQtIhm/windows/window.qt.cc
+++ b/src/mokaQtIhm/windows/window.qt.cc
@@ -98,7 +98,7 @@ Window :: Window() :
    new QShortcut(QKeySequence ( Qt::Key_F11 ), this, SLOT(callbackToggleFaces()));
    new QShortcut(QKeySequence ( Qt::Key_F12 ), this, SLOT(callbackToggleGrille()));
    new QShortcut(QKeySequence ( "Alt+F11" ), this, SLOT(callbackTournerButton()));
-   new QShortcut(QKeySequence ( Qt::Key_Space ), this, SLOT(callbackHideAllWindow()));
+//   new QShortcut(QKeySequence ( Qt::Key_Space ), this, SLOT(callbackHideAllWindow()));
    new QShortcut(QKeySequence ( Qt::Key_Up ), this, SLOT(callbackKeyUp()));
    new QShortcut(QKeySequence ( Qt::Key_Down ), this, SLOT(callbackKeyDown()));
    new QShortcut(QKeySequence ( Qt::Key_Left ), this, SLOT(callbackKeyLeft()));

--- a/src/mokaQtIhm/windows/window.qt.hh
+++ b/src/mokaQtIhm/windows/window.qt.hh
@@ -194,7 +194,7 @@ public slots:
   /**
    *  Pour detecter le changement de fenetre active dans le workspace.
    */
-  void windowActivated( QWidget * w );
+  void subWindowActivated( QMdiSubWindow * w );
   
   void callbackKeyUp();
   void callbackKeyDown();

--- a/src/mokaQtIhm/windows/window.qt.hh
+++ b/src/mokaQtIhm/windows/window.qt.hh
@@ -698,7 +698,7 @@ private:
   GMap3d :: CControlerGMap * FControler ;
 
   // Pointeur sur un workspace
-  QWorkspace * FWorkspace ;
+  QMdiArea * FWorkspace ;
   
   // Pointeur sur la fenetre de construction active
   CreationObjet * FCreationActive ;


### PR DESCRIPTION
This is a migration of Moka to Qt5. It is tested and working almost perfectly, except with an issue against HiDPI screens where picking darts does not work as intended (probably related to the way a mouse click is translated to a ray?).

(The request also contains two commits for some fixes for which there was another PR submitted before.)