### PR TITLE
Patches for Windows platform/MSVC compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ if ( MODULE_EXTRACTION_IMAGE )
   FIND_PACKAGE(ImageMagick COMPONENTS Magick++)
 
   if ( NOT (ImageMagick_Magick++_FOUND ) )
-    add_definitions(-DMODULE_EXTRACTION_WITHOUT_MAGICK)
+    add_definitions(-DMODULE_EXTRACTION_IMAGE_WITHOUT_MAGICK)
     message(STATUS "Warning: Magick++ not installed, module extraction image does not able to load images.")
   else ( NOT (ImageMagick_Magick++_FOUND ) )
      # We need to use pkg_check_modules in order to retreive the compiler options

--- a/src/lib-corefinement/2d-propagation/corefine-2d-propagation.cc
+++ b/src/lib-corefinement/2d-propagation/corefine-2d-propagation.cc
@@ -592,7 +592,7 @@ class CAngularEdgeComparator
 			 int AVertexDI)
     : FMap(AMap), FCenter(ACenter), FVertexDI(AVertexDI) {}
   
-  bool operator () (CDart * AEdge1, CDart * AEdge2)
+  bool operator () (CDart * AEdge1, CDart * AEdge2) const
   {
     CVertex v1 = *getVertex(a0(AEdge1)) - FCenter;
     CVertex v2 = *getVertex(a0(AEdge2)) - FCenter;

--- a/src/lib-corefinement/3d/face-intersection-tools.hh
+++ b/src/lib-corefinement/3d/face-intersection-tools.hh
@@ -108,7 +108,7 @@ namespace GMap3d {
       FRefY = FAxis * FRefX;
     }
     
-    int getArea(const CVertex & AVector)
+    int getArea(const CVertex & AVector) const
     {
       if (AVector.dot(FRefX) > 0.0) {
 	if (AVector.dot(FRefY) > 0.0) return 0;
@@ -120,7 +120,7 @@ namespace GMap3d {
       }
     }
 
-    bool operator () (CDart * AFace1, CDart * AFace2)
+    bool operator () (CDart * AFace1, CDart * AFace2) const
     {
       CVertex n1, n2;
       CPlane *plane;

--- a/src/lib-corefinement/common/corefine-3d-tools.cc
+++ b/src/lib-corefinement/common/corefine-3d-tools.cc
@@ -985,7 +985,7 @@ public:
 		  int AVertexDI = -1)
     : FTools(ATools), FAxis(AAxis), FVertexDI(AVertexDI) {}
 
-  bool operator () (CDart * AFace1, CDart * AFace2)
+  bool operator () (CDart * AFace1, CDart * AFace2) const
   {
     CVertex v1 = FTools.faceNormalVector(AFace1, FVertexDI);
     CVertex v2 = FTools.faceNormalVector(AFace2, FVertexDI);

--- a/src/lib-gmapkernel/g-map-vertex/gmv-assimp.cc
+++ b/src/lib-gmapkernel/g-map-vertex/gmv-assimp.cc
@@ -37,6 +37,7 @@
 #include <assimp/postprocess.h> // Post processing flags
 
 using namespace GMap3d;
+typedef unsigned int uint;
 
 //******************************************************************************
 CDart *CGMapVertex::importWithAssimp(const char* AFilename)

--- a/src/lib-gmapkernel/g-map-vertex/gmv-off.cc
+++ b/src/lib-gmapkernel/g-map-vertex/gmv-off.cc
@@ -527,7 +527,8 @@ void CGMapVertex::computeOFFSenses_VSF(vector< list<int> >& face,
                                        CVertex &baricentro,
                                        vector< int > &faceseq)
 {
-  nklein::GeometricAlgebra< double, 4 >* Points[face.size()],B,I,Line;
+  nklein::GeometricAlgebra< double, 4 >** Points = new nklein::GeometricAlgebra< double, 4 >*[face.size()];
+  nklein::GeometricAlgebra< double, 4 > B, I, Line;
   nklein::GeometricAlgebra< double, 4 > planeOuter, planeOuterD;
   nklein::GeometricAlgebra< double, 4 > planeHole, planeHoleD;
   double tol=0.00001;
@@ -658,6 +659,7 @@ void CGMapVertex::computeOFFSenses_VSF(vector< list<int> >& face,
   /** destroy */
   for(int i=0;i<face.size();i++)
     delete [] Points[i];
+  delete[] Points;
 }
 //******************************************************************************
 //CDart* CGMapVertex::importOff3D_VSF(std::istream & AStream)


### PR DESCRIPTION
Hello Guillaume,
Greetings from Poitiers,
Here's some hot-fixes for the Moka compilation on windows using the msvc compiler : 

- CMakelists.txt : 
    - Fixed missing word in definition MODULE_EXTRACTION_IMAGE_WITHOUT_MAGICK (missing _IMAGE_)
- lib-corefinement : missing multiple const qualifier  
    - `CFaceComparator::operator()(...)` **const**               (in corefine-3d-tools.cc)
    - `CAngularFaceComparator::operator()(...)` **const**    (in face_intersection-tools.hh)
    - `CAngularFaceComparator::getArea(...)` **const**       (side effect due to the last, also in face_intersection-tools.hh)
    - `CAngularEdgeComparator::operator()(...)` **const**   (in corefine-2d-propagation.cc)
- lib-gmapkernel : gmv-off.cc
    - non standard c99 variable size array (c99 not fully supported on msvc)
    - added an allocation and appropriate delete <span style="color:red">BUT behavior **not tested**</span>
- lib-gmapkernel/g-map-vertex/gmv_assimp.cc
    - non standard type `uint` used, added `typedef unsigned int uint;`
    
Each change has its own commit to easily revert it if there's ever a problem.
Wishing you a good day and hoping you had a great JFIG,

Arthur Cavalier
    